### PR TITLE
DBのカラム削除及びカラム名の変更

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,6 +10,4 @@ class Item < ApplicationRecord
 
   has_one       :shipping
 
-
-  
 end

--- a/app/models/shippingway.rb
+++ b/app/models/shippingway.rb
@@ -1,4 +1,5 @@
 class Shippingway < ApplicationRecord
     # associations
     has_many   :items
+    has_ancestry
 end

--- a/db/migrate/20200227100417_remove_shippingcharge_from_items.rb
+++ b/db/migrate/20200227100417_remove_shippingcharge_from_items.rb
@@ -1,0 +1,6 @@
+class RemoveShippingchargeFromItems < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :items, :shippingcharge_num, :integer
+    remove_column :items, :size_num, :integer
+  end
+end

--- a/db/migrate/20200227101626_rename_status_num_to_ancestry.rb
+++ b/db/migrate/20200227101626_rename_status_num_to_ancestry.rb
@@ -1,0 +1,6 @@
+class RenameStatusNumToAncestry < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :shippingways, :status_num , :ancestry
+    change_column :shippingways, :ancestry , :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_094746) do
+ActiveRecord::Schema.define(version: 2020_02_27_101626) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -70,9 +70,7 @@ ActiveRecord::Schema.define(version: 2020_02_24_094746) do
     t.bigint "brand_id", null: false
     t.bigint "category_id", null: false
     t.bigint "shippingway_id", null: false
-    t.integer "size_num", limit: 1, null: false, unsigned: true
     t.integer "condition_num", limit: 1, null: false, unsigned: true
-    t.integer "shippingcharge_num", limit: 1, null: false, unsigned: true
     t.integer "daystoship_num", limit: 1, null: false, unsigned: true
     t.string "title", null: false
     t.text "description", null: false
@@ -91,9 +89,7 @@ ActiveRecord::Schema.define(version: 2020_02_24_094746) do
     t.index ["condition_num"], name: "index_items_on_condition_num"
     t.index ["daystoship_num"], name: "index_items_on_daystoship_num"
     t.index ["seller_id"], name: "index_items_on_seller_id"
-    t.index ["shippingcharge_num"], name: "index_items_on_shippingcharge_num"
     t.index ["shippingway_id"], name: "index_items_on_shippingway_id"
-    t.index ["size_num"], name: "index_items_on_size_num"
     t.index ["title"], name: "index_items_on_title"
   end
 
@@ -109,7 +105,7 @@ ActiveRecord::Schema.define(version: 2020_02_24_094746) do
   end
 
   create_table "shippingways", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "status_num", limit: 1, null: false, unsigned: true
+    t.string "ancestry", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
#why
開発を進めるにあたってAssociationのあるテーブル間に用途の重複したカラムを発見、不要と判断したため。
また、着払い、元払いを起点に配送方法が分岐するため、shippingwaysのstatus_numカラムをgemのancestryへ変更した方が良いと思われたため。

#what
・問題なくdb:migrateできるか。
・db:migrate後に以下状態となっているか。
　itemsテーブルよりshipping_charge_numが削除されているか。
　shippingwayテーブルのstatus_numがancestryに変更されているか。また、データ型がstring型に変更されているか。