### PR TITLE
Create seeds size and shippingways

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,7 @@ class Item < ApplicationRecord
   # associations
   belongs_to    :brand
   belongs_to    :category
-  belongs_to    :shippingway
+  belongs_to    :shippingway, optional: true
   belongs_to    :buyer, class_name: "User", optional: true
   belongs_to    :seller, class_name: "User"
 

--- a/app/models/shippingway.rb
+++ b/app/models/shippingway.rb
@@ -1,5 +1,5 @@
 class Shippingway < ApplicationRecord
-    # associations
-    has_many   :items
-    has_ancestry
+  # associations
+  has_many   :items
+  has_ancestry
 end

--- a/db/migrate/20200228084245_change_ancestry_to_shippingways.rb
+++ b/db/migrate/20200228084245_change_ancestry_to_shippingways.rb
@@ -1,0 +1,6 @@
+class ChangeAncestryToShippingways < ActiveRecord::Migration[5.2]
+  def change
+    change_column :shippingways, :ancestry , :string
+    add_index :shippingways, :ancestry    
+  end
+end

--- a/db/migrate/20200228084245_change_ancestry_to_shippingways.rb
+++ b/db/migrate/20200228084245_change_ancestry_to_shippingways.rb
@@ -1,6 +1,7 @@
 class ChangeAncestryToShippingways < ActiveRecord::Migration[5.2]
   def change
-    change_column :shippingways, :ancestry , :string
-    add_index :shippingways, :ancestry    
+    remove_column :shippingways, :ancestry , :string
+    add_column :shippingways, :ancestry , :string, null: true
+    add_index :shippingways, :ancestry
   end
 end

--- a/db/migrate/20200228102559_change_foreign_key_to_shippingway_id.rb
+++ b/db/migrate/20200228102559_change_foreign_key_to_shippingway_id.rb
@@ -1,0 +1,6 @@
+class ChangeForeignKeyToShippingwayId < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference(:items, :shippingway, null: false, foreign_key: true)
+    add_reference(:items, :shippingway, null: true, foreign_key: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_27_101626) do
+ActiveRecord::Schema.define(version: 2020_02_28_084245) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -105,10 +105,11 @@ ActiveRecord::Schema.define(version: 2020_02_27_101626) do
   end
 
   create_table "shippingways", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "ancestry", null: false
+    t.string "ancestry"
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["ancestry"], name: "index_shippingways_on_ancestry"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_28_084245) do
+ActiveRecord::Schema.define(version: 2020_02_28_102559) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -69,7 +69,6 @@ ActiveRecord::Schema.define(version: 2020_02_28_084245) do
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "brand_id", null: false
     t.bigint "category_id", null: false
-    t.bigint "shippingway_id", null: false
     t.integer "condition_num", limit: 1, null: false, unsigned: true
     t.integer "daystoship_num", limit: 1, null: false, unsigned: true
     t.string "title", null: false
@@ -83,6 +82,7 @@ ActiveRecord::Schema.define(version: 2020_02_28_084245) do
     t.bigint "seller_id", null: false
     t.bigint "buyer_id"
     t.integer "status_num", limit: 1, null: false, unsigned: true
+    t.bigint "shippingway_id"
     t.index ["brand_id"], name: "index_items_on_brand_id"
     t.index ["buyer_id"], name: "index_items_on_buyer_id"
     t.index ["category_id"], name: "index_items_on_category_id"
@@ -105,10 +105,10 @@ ActiveRecord::Schema.define(version: 2020_02_28_084245) do
   end
 
   create_table "shippingways", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "ancestry"
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "ancestry"
     t.index ["ancestry"], name: "index_shippingways_on_ancestry"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,3 +6,4 @@ if Rails.env == "development"
   require './db/seeds/user.rb'
   require './db/seeds/item.rb'
 end
+# itemとshippingwayの外部キーを(null: true)に変更してから実行すること。

--- a/db/seeds/category.rb
+++ b/db/seeds/category.rb
@@ -5,11 +5,23 @@ lady = Category.create(name: "レディース")
 lady_tops = lady.children.create(name: "トップス")
 
 # 孫：レディース／トップス
-lady_tops.children.create([{name: "Tシャツ/カットソー(半袖/袖なし)"},{name: "Tシャツ/カットソー(七分/長袖)"},{name: "その他"}])
+lady_tops_items = lady_tops.children.create([{name: "Tシャツ/カットソー(半袖/袖なし)"},{name: "Tシャツ/カットソー(七分/長袖)"},{name: "その他"}])
 
 # 子：レディース／アウター
 lady_jacket = lady.children.create(name: "ジャケット/アウター")
 
 # 孫：レディース／アウター
-lady_jacket.children.create([{name: "テーラードジャケット"},{name: "ノーカラージャケット"},{name: "Gジャン/デニムジャケット"},{name: "その他"}])
+lady_jacket_items = lady_jacket.children.create([{name: "テーラードジャケット"},{name: "ノーカラージャケット"},{name: "Gジャン/デニムジャケット"},{name: "その他"}])
 
+# サイズ
+ary_size = [{name: "XXS以下"},{name: "XS(SS)"},{name: "S"},{name: "M"},{name: "L"},{name: "XL(LL)"},{name: "2XL(3L)"},{name: "3XL(4L)"},{name: "4XL(5L)以上"},{name: "FREE SIZE"}]
+
+# 曽孫：レディース／トップス／孫たち
+lady_tops.children.each do |size|
+  size.children.create(ary_size)
+end
+
+# 曽孫：レディース／アウター／孫たち
+lady_jacket.children.each do |size|
+  size.children.create(ary_size)
+end

--- a/db/seeds/item.rb
+++ b/db/seeds/item.rb
@@ -12,10 +12,9 @@ ary_categoryid = [3,4,5,7,8,9,10,3,4,5]
   price =  20000
   profit_price = 18000
   seller_id = n+1
-  shippingcharge_num = 0
-  shippingway_id = 0
-  size_num = 0
+  shippingway_id = nil
   status_num = 0
+  sold_at = nil
   title = "商品#{n+1}"
   Item.create!(brand_id: brand_id,
     buyer_id:            buyer_id,
@@ -27,10 +26,9 @@ ary_categoryid = [3,4,5,7,8,9,10,3,4,5]
     price:               price,
     profit_price:        profit_price,
     seller_id:           seller_id,
-    shippingcharge_num:  shippingcharge_num,
     shippingway_id:      shippingway_id,
-    size_num:            size_num,
     status_num:          status_num,
+    sold_at:             sold_at,
     title:               title)
 end
 

--- a/db/seeds/shippingway.rb
+++ b/db/seeds/shippingway.rb
@@ -1,15 +1,11 @@
-Shippingway.seed(:id,
-  { :id =>  0, :status_num => 1, :name => "未定"},
-  { :id =>  1, :status_num => 1, :name => "らくらくFRIMA便"},
-  { :id =>  2, :status_num => 1, :name => "ゆうメール"},
-  { :id =>  3, :status_num => 1, :name => "レターパック"},
-  { :id =>  4, :status_num => 1, :name => "普通郵便（定形、定形外）"},
-  { :id =>  5, :status_num => 1, :name => "クロネコヤマト"},
-  { :id =>  6, :status_num => 1, :name => "ゆうパック"},
-  { :id =>  7, :status_num => 1, :name => "クリックポスト"},
-  { :id =>  8, :status_num => 1, :name => "ゆうパケット"},
-  { :id =>  9, :status_num => 2, :name => "未定"},
-  { :id => 10, :status_num => 2, :name => "クロネコヤマト"},
-  { :id => 11, :status_num => 2, :name => "ゆうパック"},
-  { :id => 12, :status_num => 2, :name => "ゆうメール"}
-)
+# 親：配送料の負担
+advancepay = Shippingway.create(name: "送料込み（出品者負担）")
+
+# 子：配送の方法（送料込み（出品者負担））
+advancepay_way = advancepay.children.create([{ name: "未定"},{ name: "らくらくFRIMA便"},{ name: "ゆうメール"},{ name: "レターパック"},{ name: "普通郵便（定形、定形外）"},{ name: "クロネコヤマト"},{ name: "ゆうパック"},{ name: "クリックポスト"},{ name: "ゆうパケット"}])
+
+# 親：配送料の負担
+deliverypay = Shippingway.create(name: "着払い（購入者負担）")
+
+# 子：配送の方法（送料込み（出品者負担））
+deliverypay_way = deliverypay.children.create([{ name: "未定"},{ name: "クロネコヤマト"},{ name: "ゆうパック"},{ name: "ゆうメール"}])


### PR DESCRIPTION
### Why

今後のアプリケーション開発の工数削減に必要なため。

### What

seedデータ作成処理を修正しました。

- shippingwayのseedデータをancestryで保存するように対応。

- shippingwayテーブルのancestryカラムがnull不可になっていたので、null許可に変更 
  
- itemテーブルのshippingway_idをnull不可からnull許可に変更。

- categoryに追加するシードデータの曽孫階層にサイズを追加。
