### PR TITLE
ユーザー新規登録サーバーサイド

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,15 +113,12 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-
-    enum_help (0.0.17)
-      activesupport (>= 3.0.0)
-
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
-
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.9.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -371,11 +368,8 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
-
-  enum_help
-
   dotenv-rails
-
+  enum_help
   factory_bot_rails
   faker
   faker-japanese

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,14 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth
   protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname,:email,:first_name,:last_name,:first_name_kana,:last_name_kana,:birthday])
+  end
+
 
   private
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -73,6 +73,7 @@
           = f.label :"生年月日"
           %span.registrations-new-main-input-class-field__subtitle 必須
           %br/
+          -# <!-- 77行目は後で利用する予定です。年月日を分けた入力が出来るフィールドです。 -->
           -# != sprintf(f.date_select(:birthday, prefix:'birthday',with_css_classes:'registrations-new-main-input-class-field__birthday__text-box', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s'),'年','月')+'日'
           = f.date_field :birthday             
         .registrations-new-main-input-class-field

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -18,7 +18,7 @@
     .registrations-new-main-title
       %h2 会員情報登録
     .registrations-new-main-input-class
-      = form_with(model: @users, locale: true, url: registration_path(resource_name)) do |f|
+      = form_with(model: @user, locale: true, url: registration_path(resource_name)) do |f|
         .registrations-new-main-input-class-field
           = f.label :"ニックネーム"
           %span.registrations-new-main-input-class-field__subtitle 必須
@@ -73,7 +73,8 @@
           = f.label :"生年月日"
           %span.registrations-new-main-input-class-field__subtitle 必須
           %br/
-          != sprintf(f.date_select(:birthday, prefix:'birthday',with_css_classes:'registrations-new-main-input-class-field__birthday__text-box', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s'),'年','月')+'日'             
+          -# != sprintf(f.date_select(:birthday, prefix:'birthday',with_css_classes:'registrations-new-main-input-class-field__birthday__text-box', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s'),'年','月')+'日'
+          = f.date_field :birthday             
         .registrations-new-main-input-class-field
           %br/
           %P.registrations-new-main-input-class-field__text-Identity-information ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
@@ -84,7 +85,7 @@
             「次へ進む」のボタンを押すことにより、#{link_to "利用規約","#URL",class:"registrations-new-main-input-class-field__consent--link" }に同意したものとみなします。
         .registrations-new-main-input-class-field
           .registrations-new-main-input-class-field__botton
-            = f.button "送信",onclick: "submit();",value: "次へ進む",class:"registrations-new-main-input-class-field__botton--text" 
+            = f.submit "送信",value: "次へ進む",class:"registrations-new-main-input-class-field__botton--text" 
         .registrations-new-main-input-class-field
           %P.registrations-new-main-input-class-field__bottom-link
             #{link_to "本人情報の登録について＞","#URL",class:"registrations-new-main-input-class-field__bottom-link--link" }


### PR DESCRIPTION
#What
・ユーザーのデータをデータベースに登録できるようにする
（ニックネーム、メールアドレス、パスワード、名前（全角）、名前カナ（全角）、生年月日
#why
・ユーザーがログインするために必要な情報を登録するため

※生年月日（birthday)はdate_filedで一つにしました。
後で修正の予定です。
