### PR TITLE
itemテーブルのカラム編集用migrationファイルの修正

### DIFF
--- a/db/migrate/20200303102404_remove_columns_from_items.rb
+++ b/db/migrate/20200303102404_remove_columns_from_items.rb
@@ -17,7 +17,7 @@ class RemoveColumnsFromItems < ActiveRecord::Migration[5.2]
     add_reference(:items, :buyer,          null: true,  foreign_key: {to_table: :users})
     add_reference(:items, :buyer_address,  null: true,  foreign_key: {to_table: :addresses})
     add_column(:items,:sold_at,:datetime)
-    add_column(:items,:status_num,null: false, limit: 1, unsigned: true, default: 0)
+    add_column(:items,:status_num,:integer,null: false, limit: 1, unsigned: true, default: 0)
     remove_reference(:items, :user,        null: false, foreign_key: true,after: :id)
     remove_reference(:items, :address,     null: false, foreign_key: true,after: :user_id)
   end


### PR DESCRIPTION
### What

rails db:migrate で 20200303102404_remove_columns_from_items.rbを
適用すると、ロールバックできなくなる現象を修正しました。

### Why

migrationの履歴を正常な状態に保つためには必要なため。
