### PR TITLE
商品詳細画面の「編集ボタン」と「購入ボタン」の実装

### DIFF
--- a/app/assets/stylesheets/modules/_items-show.scss
+++ b/app/assets/stylesheets/modules/_items-show.scss
@@ -91,7 +91,6 @@
       border: 1px solid #3CCACE;
       color: #fff;
       width: 60%;
-      font-size: 18px;
       border-radius: 100px;
     }
   }
@@ -99,4 +98,36 @@
 .items-show-links{
   display:flex;
   justify-content: space-between;
+}
+
+.items-show-button{
+  width:700px;
+  &__edit{
+    margin:0 auto;
+    text-align: center;
+    font-size: 18px;
+    line-height: 48px;
+    background: #3CCACE;
+    border: 1px solid #3CCACE;
+    width: 60%;
+    border-radius: 100px;
+    &--link{
+      color: #fff;
+      text-decoration: none;
+    }
+  }
+  &__purchase{
+    margin:0 auto;
+    text-align: center;
+    font-size: 18px;
+    line-height: 48px;
+    background: #3CCACE;
+    border: 1px solid #3CCACE;
+    width: 60%;
+    border-radius: 100px;
+    &--link{
+      color: #fff;
+      text-decoration: none;
+    }
+  }
 }

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -73,10 +73,10 @@
                   %td.items-show-detail__table--td
                     =@item.daystoship_num_i18n
           .items-show-button
-            - if @item.user_id == current_user.id
+            - if user_signed_in? && @item.user_id == current_user.id
               .items-show-button__edit
                 =link_to '編集する', edit_item_path(@item.id),class:"items-show-button__edit--link"
-            -else
+            - else
               .items-show-button__purchase
                 =link_to '購入する', new_item_trade_path(@item.id) ,class:"items-show-button__purchase--link"
           .items-show-other

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -72,6 +72,13 @@
                   %th.items-show-detail__table--th 発送日の目安
                   %td.items-show-detail__table--td
                     =@item.daystoship_num_i18n
+          .items-show-button
+            - if @item.user_id == current_user.id
+              .items-show-button__edit
+                =link_to '編集する', edit_item_path(@item.id),class:"items-show-button__edit--link"
+            -else
+              .items-show-button__purchase
+                =link_to '購入する', new_item_trade_path(@item.id) ,class:"items-show-button__purchase--link"
           .items-show-other
             %ul.items-show-other__favorite
               %li.items-show-other__favorite--btn


### PR DESCRIPTION
#why
ログインしているユーザに依って、「編集ボタン」、「購入ボタン」の表示の切り替えが必要なため。

#what
・出品者がログインしているときは「編集ボタン」が表示されていること。

・他ユーザ、もしくは、ユーザログインが無い場合は「購入ボタン」が表示されていること。

出品者ログイン時
[![Screenshot from Gyazo](https://gyazo.com/3e593d3ce5ea75133310c056ce4d7123/raw)](https://gyazo.com/3e593d3ce5ea75133310c056ce4d7123)

ユーザログインなし時
[![Screenshot from Gyazo](https://gyazo.com/d41244c9d0bd14f49179d7335c0a7b2d/raw)](https://gyazo.com/d41244c9d0bd14f49179d7335c0a7b2d)