### PR TITLE
Item image upload2

### DIFF
--- a/app/assets/javascripts/item-image-container.js
+++ b/app/assets/javascripts/item-image-container.js
@@ -55,39 +55,39 @@ $('.item-image-container__unit--guide').on('drop',function(event){
 });
 
 //次の画像機能の実装で使用する予定のためコメントアウトしています。
-// $(document).on('click','.item-image-container__unit--preview a',function(){
+$(document).on('click','.item-image-container__unit--preview a',function(){
 
-//   var index = $(".item-image-container__unit--preview a").index(this);
+  var index = $(".item-image-container__unit--preview a").index(this);
 
-//   files_array.splice(index - 1, 1);
+  files_array.splice(index - 1, 1);
 
-//   $(this).parent().parent().parent().remove();
-// });
+  $(this).parent().parent().parent().remove();
+});
 
-// var aj_url = window.location.pathname;
-// var aj_url = '/users/1/items';
+var aj_url = window.location.pathname;
+var aj_url = '/users/1/items';
 
-// $('#new_item').on('submit', function(e){
-//   e.preventDefault();
+$('#new_item').on('submit', function(e){
+  e.preventDefault();
   
-//   var formData = new FormData($(this).get(0));
+  var formData = new FormData($(this).get(0));
   
-//   files_array.forEach(function(file){
-//    formData.append("image[images][]" , file)
-//   });
+  files_array.forEach(function(file){
+   formData.append("image[images][]" , file)
+  });
   
-//   $.ajax({
-//     url:         aj_url,
-//     type:        "POST",
-//     data:        formData,
-//     contentType: false,
-//     processData: false,
-//     dataType:   'json',
-//   })
-//   .done(function(){
-//     alert('出品に成功しました！');
-//   })
-//   .fail(function(){
-//     alert('出品に失敗しました！');
-//   });
-// });
+  $.ajax({
+    url:         aj_url,
+    type:        "POST",
+    data:        formData,
+    contentType: false,
+    processData: false,
+    dataType:   'json',
+  })
+  .done(function(){
+    alert('出品に成功しました！');
+  })
+  .fail(function(){
+    alert('出品に失敗しました！');
+  });
+});

--- a/app/assets/javascripts/item-image-container.js
+++ b/app/assets/javascripts/item-image-container.js
@@ -54,7 +54,7 @@ $('.item-image-container__unit--guide').on('drop',function(event){
   
 });
 
-//次の画像機能の実装で使用する予定のためコメントアウトしています。
+
 $(document).on('click','.item-image-container__unit--preview a',function(){
 
   var index = $(".item-image-container__unit--preview a").index(this);
@@ -63,31 +63,31 @@ $(document).on('click','.item-image-container__unit--preview a',function(){
 
   $(this).parent().parent().parent().remove();
 });
+//次の画像機能の実装で使用する予定のためコメントアウトしています。
+// var aj_url = window.location.pathname;
+// var aj_url = '/users/1/items';
 
-var aj_url = window.location.pathname;
-var aj_url = '/users/1/items';
-
-$('#new_item').on('submit', function(e){
-  e.preventDefault();
+// $('#new_item').on('submit', function(e){
+//   e.preventDefault();
   
-  var formData = new FormData($(this).get(0));
+//   var formData = new FormData($(this).get(0));
   
-  files_array.forEach(function(file){
-   formData.append("image[images][]" , file)
-  });
+//   files_array.forEach(function(file){
+//    formData.append("image[images][]" , file)
+//   });
   
-  $.ajax({
-    url:         aj_url,
-    type:        "POST",
-    data:        formData,
-    contentType: false,
-    processData: false,
-    dataType:   'json',
-  })
-  .done(function(){
-    alert('出品に成功しました！');
-  })
-  .fail(function(){
-    alert('出品に失敗しました！');
-  });
-});
+//   $.ajax({
+//     url:         aj_url,
+//     type:        "POST",
+//     data:        formData,
+//     contentType: false,
+//     processData: false,
+//     dataType:   'json',
+//   })
+//   .done(function(){
+//     alert('出品に成功しました！');
+//   })
+//   .fail(function(){
+//     alert('出品に失敗しました！');
+//   });
+// });

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -1,6 +1,4 @@
 $(function(){
-  console.log('hi');
-  
   //DataTransferオブジェクトで、データを格納する箱を作る
   var dataBox = new DataTransfer();
   //querySelectorでfile_fieldを取得
@@ -39,7 +37,7 @@ $(function(){
                       </div>
                     </li>`
         $(html).appendTo(".item-image-container__unit ul").trigger("build");
-        console.log(dataBox);
+        
       };
       if(dataBox.items.length > 4){
         return false;

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -23,7 +23,7 @@ $(function(){
       //読み込みが完了すると、srcにfileのURLを格納
       fileReader.onloadend = function() {
         var src = fileReader.result
-        var html =  `<li class="item-image-container__unit--preview" data-num="${i + 1}">
+        var html =  `<li class="item-image-container__unit--preview" >
                       <div class="item-image-container__unit--caption">
                         <img src="${src}">
                       </div>

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -1,5 +1,6 @@
 $(function(){
   console.log('hi');
+  
   //DataTransferオブジェクトで、データを格納する箱を作る
   var dataBox = new DataTransfer();
   //querySelectorでfile_fieldを取得
@@ -20,10 +21,11 @@ $(function(){
       var num = $('.item-image-container__unit--preview').length + 1 + i
       fileReader.readAsDataURL(file);
       
+      
       //読み込みが完了すると、srcにfileのURLを格納
       fileReader.onloadend = function() {
         var src = fileReader.result
-        var html =  `<li class="item-image-container__unit--preview"  id="visible" data-num="${i + 1}">
+        var html =  `<li class="item-image-container__unit--preview" data-num="${i + 1}">
                       <div class="item-image-container__unit--caption">
                         <img src="${src}">
                       </div>
@@ -37,8 +39,12 @@ $(function(){
                       </div>
                     </li>`
         $(html).appendTo(".item-image-container__unit ul").trigger("build");
-        
+        console.log(dataBox);
       };
+      if(dataBox.items.length > 4){
+        return false;
+      }
     });
+    
   });
 });

--- a/app/assets/javascripts/upload.js
+++ b/app/assets/javascripts/upload.js
@@ -9,7 +9,6 @@ $(function(){
     //選択したfileのオブジェクトをpropで取得
     var files = $('input[type="file"]').prop('files')[0];
     
-
     $.each(this.files, function(i, file){
       //FileReaderのreadAsDataURLで指定したFileオブジェクトを読み込む
       var fileReader = new FileReader();
@@ -24,7 +23,7 @@ $(function(){
       //読み込みが完了すると、srcにfileのURLを格納
       fileReader.onloadend = function() {
         var src = fileReader.result
-        var html =  `<li class="item-image-container__unit--preview" id="visible" data-num="${i + 1}">
+        var html =  `<li class="item-image-container__unit--preview"  id="visible" data-num="${i + 1}">
                       <div class="item-image-container__unit--caption">
                         <img src="${src}">
                       </div>
@@ -38,8 +37,7 @@ $(function(){
                       </div>
                     </li>`
         $(html).appendTo(".item-image-container__unit ul").trigger("build");
-        var result = $('.item-image-container__unit--preview').data('num');
-        console.log(result);
+        
       };
     });
   });

--- a/app/assets/stylesheets/_item-image-container.scss
+++ b/app/assets/stylesheets/_item-image-container.scss
@@ -115,7 +115,7 @@
 .image-upload-dropfile-hidden{
   display: none;
 }
-.boxFileSelect{
+.image-upload-dropfile-entire{
   width: 100%;
   height: 150px;
   margin: auto;

--- a/app/assets/stylesheets/_item-image-container.scss
+++ b/app/assets/stylesheets/_item-image-container.scss
@@ -110,3 +110,14 @@
     }
   }
 }
+
+
+.image-upload-dropfile-hidden{
+  display: none;
+}
+.boxFileSelect{
+  width: 100%;
+  height: 150px;
+  margin: auto;
+  cursor: pointer;
+}

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -13,14 +13,17 @@
           %p.item-image-container__lead
             最大5枚までアップロードできます
           .item-image-container__unit
-            %ul
-          = f.fields_for :item_images do |i|
-            = i.file_field :image, multiple: true, class: 'image-upload-dropfile hidden', type: 'file', name: "item_images[image][]"
-            .item-image-container__unit--guide
-              .have-image
-                = icon('fas','camera')
-                %p#d-d-delete ドラッグ&ドロップ
-                %p#click-delete またはクリックしてファイルをアップロード
+            = f.fields_for :item_images do |i|
+              %ul
+                
+              .item-image-container__unit--guide
+                %label(for="image-label")
+                  = i.file_field :image, multiple: true, class: 'image-upload-dropfile-hidden', id:"image-label",type: 'file', name: "item_images[image][]"
+                  %div.boxFileSelect
+                  .have-image
+                    = icon('fas','camera')
+                    %p#d-d-delete ドラッグ&ドロップ
+                    %p#click-delete またはクリックしてファイルをアップロード
         %hr.items-new-hr
         .items-new-first
           .items-new-first__head

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -19,7 +19,7 @@
               .item-image-container__unit--guide
                 %label(for="image-label")
                   = i.file_field :image, multiple: true, class: 'image-upload-dropfile-hidden', id:"image-label",type: 'file', name: "item_images[image][]"
-                  %div.boxFileSelect
+                  %div.image-upload-dropfile-entire
                   .have-image
                     = icon('fas','camera')
                     %p#d-d-delete ドラッグ&ドロップ


### PR DESCRIPTION
### What
商品出品の際の画像をクリックアップロードで実装しました。
multiple:trueで複数投稿可能にしていますが、5枚以上フォームに入れようとしてもJS側で5枚までのバリデーションをかけています。
Gif画像チェックお願いします。
DBにもしっかり5枚までで、Itemのidと紐付いて保存されます。

[![Image from Gyazo](https://i.gyazo.com/f1fa1638bb474d6fc58cb2ea6775ca4a.gif)](https://gyazo.com/f1fa1638bb474d6fc58cb2ea6775ca4a)
### Why
画像がないとどんな商品か分からない為。
ユーザーは複数の画像を投稿したいであろうから。