### PR TITLE
ユーザ登録のvalidationの一部機能が停止していたためdebug

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,8 +18,8 @@ class User < ApplicationRecord
 
   validates :nickname, presence: true, length: { maximum: 15 }
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX, message: 'は有効でありません。' }
-  validates :password, presence: true, length: { in: 7..255 }, format: { with: VALID_PASSWORD_REGEX, message: 'は英字と数字両方を含むパスワードを設定してください'}
-  validates :password_confirmation, presence: true, length: { in:7..255}, format: {with:VALID_PASSWORD_REGEX, message: 'は英字と数字両方を含むパスワードを設定してください'}
+  validates :password, presence: true,confirmation:true, length: { in: 7..255 }, format: { with: VALID_PASSWORD_REGEX, message: 'は英字と数字両方を含むパスワードを設定してください'}
+  validates :password_confirmation, presence: true
   validates :last_name, presence: true, length: { maximum: 15 }
   validates :first_name, presence: true, length: { maximum: 15 }
   validates :last_name_kana, presence: true, length: { maximum: 20 }, format: { with: VALID_KATAKANA_REGEX, message: 'はカタカナで入力して下さい。'}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,15 +16,11 @@ class User < ApplicationRecord
   VALID_KATAKANA_REGEX = /\A[\p{katakana}\p{blank}ー－]+\z/
   VALID_PHONE_REGEX = /\A\d{10}$|^\d{11}\z/
 
-  validates :nickname, presence: true, length: { maximum: 15 }
+  validates :nickname,:last_name,:first_name, presence: true, length: { maximum: 15 }
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX, message: 'は有効でありません。' }
   validates :password, presence: true,confirmation:true, length: { in: 7..255 }, format: { with: VALID_PASSWORD_REGEX, message: 'は英字と数字両方を含むパスワードを設定してください'}
-  validates :password_confirmation, presence: true
-  validates :last_name, presence: true, length: { maximum: 15 }
-  validates :first_name, presence: true, length: { maximum: 15 }
-  validates :last_name_kana, presence: true, length: { maximum: 20 }, format: { with: VALID_KATAKANA_REGEX, message: 'はカタカナで入力して下さい。'}
-  validates :first_name_kana, presence: true, length: { maximum: 20 }, format: { with: VALID_KATAKANA_REGEX, message: 'はカタカナで入力して下さい。'}
-  validates :birthday, presence: true
+  validates :password_confirmation,:birthday, presence: true
+  validates :last_name_kana,:first_name_kana,  presence: true, length: { maximum: 20 }, format: { with: VALID_KATAKANA_REGEX, message: 'はカタカナで入力して下さい。'}
   validates :telephone_number, presence: true, format: { with: VALID_PHONE_REGEX, message: 'は有効でありません。'}
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module FreemarketSample63a
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
#why
password_confirmationがpaswordと同値でなくても登録できてしまう不具合を修正。
また日本語化対応を実施。

#what
同値でない際に一致しませんのエラーが表示されるか。

▪️password_confirmationがnull
[![Screenshot from Gyazo](https://gyazo.com/bf513bf4c924dfba793c1e85e67eef53/raw)](https://gyazo.com/bf513bf4c924dfba793c1e85e67eef53)

▪️password_confirmationがpasswordと入力値が異なる
[![Screenshot from Gyazo](https://gyazo.com/5e58a5211edef0114067649cee62abf0/raw)](https://gyazo.com/5e58a5211edef0114067649cee62abf0)

▪️password_confirmationがpasswordと入力値が同値（正規入力）
[![Screenshot from Gyazo](https://gyazo.com/9da64d3fded4a0f590155b1de9e9bff1/raw)](https://gyazo.com/9da64d3fded4a0f590155b1de9e9bff1)