### PR TITLE
getメソッドでのページ遷移時にjQueryが無効になるバグの修正

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,33 +1,30 @@
-document.addEventListener(
-  "DOMContentLoaded", e => {
-    if (document.getElementById("token_submit") != null) { 
-      Payjp.setPublicKey(gon.payip_access_key); 
-      let btn = document.getElementById("token_submit"); 
-      btn.addEventListener("click", e => { 
-        e.preventDefault(); 
-        let card = {
-          number: document.getElementById("card_number").value,
-          cvc: document.getElementById("cvc").value,
-          exp_month: document.getElementById("exp_month").value,
-          exp_year: document.getElementById("exp_year").value
-        }; 
-        Payjp.createToken(card, (status, response) => {
-          if (status === 200) { 
-            $("#card_number").removeAttr("name");
-            $("#cvc").removeAttr("name");
-            $("#exp_month").removeAttr("name");
-            $("#exp_year").removeAttr("name"); 
-            $("#card_token").append(
-              $('<input type="hidden" name="payjp-token">').val(response.id)
-            ); 
-            document.inputForm.submit();
-            alert("登録が完了しました"); 
-          } else {
-            alert("カード情報が正しくありません。"); 
-          }
-        });
+$(document).on('turbolinks:load', function() {
+  if (document.getElementById("token_submit") != null) { 
+    Payjp.setPublicKey(gon.payip_access_key); 
+    let btn = document.getElementById("token_submit"); 
+    btn.addEventListener("click", e => { 
+      e.preventDefault(); 
+      let card = {
+        number: document.getElementById("card_number").value,
+        cvc: document.getElementById("cvc").value,
+        exp_month: document.getElementById("exp_month").value,
+        exp_year: document.getElementById("exp_year").value
+      }; 
+      Payjp.createToken(card, (status, response) => {
+        if (status === 200) { 
+          $("#card_number").removeAttr("name");
+          $("#cvc").removeAttr("name");
+          $("#exp_month").removeAttr("name");
+          $("#exp_year").removeAttr("name"); 
+          $("#card_token").append(
+            $('<input type="hidden" name="payjp-token">').val(response.id)
+          ); 
+          document.inputForm.submit();
+          alert("登録が完了しました"); 
+        } else {
+          alert("カード情報が正しくありません。"); 
+        }
       });
-    }
-  },
-  false
-);
+    });
+  };
+});


### PR DESCRIPTION
#why
クレジットカードをマイページから登録しようとした際に、送信ボタンを押しても初回のみボタンが動作しないバグがあったため。

#what
マイページから移動し、そのままクレジットカードの登録ができるかどうか。

[![Screenshot from Gyazo](https://gyazo.com/6f8a073f1e0a808c01b2abce82d6ad25/raw)](https://gyazo.com/6f8a073f1e0a808c01b2abce82d6ad25)

[![Screenshot from Gyazo](https://gyazo.com/1cbd83ddf4acf508191b247d974a29fd/raw)](https://gyazo.com/1cbd83ddf4acf508191b247d974a29fd)