### PR TITLE
購入画面、購入ボタンの表示／非表示処理の実装と、has_manyのテストコードを追加。

### DIFF
--- a/app/helpers/trades_helper.rb
+++ b/app/helpers/trades_helper.rb
@@ -1,2 +1,7 @@
 module TradesHelper
+
+  def card_exists_and_addres_exists?
+    return unless @default_card_information.nil? || @address.nil? 
+  end
+
 end

--- a/app/helpers/trades_helper.rb
+++ b/app/helpers/trades_helper.rb
@@ -1,7 +1,7 @@
 module TradesHelper
 
-  def card_exists_and_addres_exists?
-    return unless @default_card_information.nil? || @address.nil? 
+  def card_present_and_addres_present?
+    @default_card_information.present? && @address.present?
   end
 
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -81,7 +81,10 @@
                 = link_to '出品を取り消す', item_path(@item.id),method: :delete,class:"items-show-button__cancel--link", data: { confirm: '出品を取り消します。よろしいですか？' }
             - else
               .items-show-button__purchase
-                = link_to '購入する', new_item_trade_path(@item.id) ,class:"items-show-button__purchase--link"
+                - if user_signed_in?
+                  = link_to '購入する', new_item_trade_path(@item.id) ,class:"items-show-button__purchase--link"
+                - else
+                  = link_to 'ログイン', new_user_session_path, class:"items-show-button__purchase--link"
           .items-show-other
             %ul.items-show-other__favorite
               %li.items-show-other__favorite--btn

--- a/app/views/trades/new.html.haml
+++ b/app/views/trades/new.html.haml
@@ -75,6 +75,7 @@
                     = @address.number 
                     %br/
                     = @address.building 
-            .trades-new-buy-content
-              = button_tag "購入する"
+            - unless @default_card_information.nil? || @address.nil?
+              .trades-new-buy-content
+                = button_tag "購入する"
   %footer.trades-new-footer

--- a/app/views/trades/new.html.haml
+++ b/app/views/trades/new.html.haml
@@ -75,7 +75,7 @@
                     = @address.number 
                     %br/
                     = @address.building 
-            - unless @default_card_information.nil? || @address.nil?
+            - if card_exists_and_addres_exists?
               .trades-new-buy-content
                 = button_tag "購入する"
   %footer.trades-new-footer

--- a/app/views/trades/new.html.haml
+++ b/app/views/trades/new.html.haml
@@ -39,9 +39,6 @@
                         %span.trades-new-buy-register-text--new
                           登録してください
                 - else
-                  = link_to "#", class: "trades-new-buy-user-info-fix" do
-                    %span.trades-new-buy-register-text--edit
-                      変更する
                   %p.trades-new-buy-user-info-text__cardinfo
                     .creditcards-show-confirmation__contents
                       .creditcards-show-confirmation__card-number
@@ -75,7 +72,7 @@
                     = @address.number 
                     %br/
                     = @address.building 
-            - if card_exists_and_addres_exists?
+            - if card_present_and_addres_present?
               .trades-new-buy-content
                 = button_tag "購入する"
   %footer.trades-new-footer

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -9,6 +9,22 @@ FactoryBot.define do
     association :area
     association :user
 
+    trait :with_ladies_items do
+      after(:build) do |address|
+        address.items = []
+        address.items << FactoryBot.build(:item, title: "ポーチ")
+        address.items << FactoryBot.build(:item, title: "ダウンジャケット")
+      end
+    end
+
+    trait :with_ladies_trades do
+      after(:build) do |address|
+        address.trades = []
+        address.trades << FactoryBot.build(:trade, status_num: 1)
+        address.trades << FactoryBot.build(:trade, status_num: 2)
+      end
+    end
+
   end
 
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -6,5 +6,13 @@ RSpec.describe Address, type: :model do
       address = build(:address)
       expect(address).to be_valid
     end
+    it "is valid address with_ladies_items" do
+      address = build(:address, :with_ladies_items)
+      expect(address).to be_valid
+    end
+    it "is valid address with_ladies_trades" do
+      address = build(:address, :with_ladies_trades)
+      expect(address).to be_valid
+    end
   end
 end

--- a/spec/models/trade_spec.rb
+++ b/spec/models/trade_spec.rb
@@ -1,32 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Trade, type: :model do
-  describe '#create' do
-    # Factory_botでassociationを組むと外部キーの未入力テストが失敗するので、
-    # 解決するまでコメントアウトする。
-    # it "is invalid without a item_id" do
-    #   trade = build(:trade)
-    #   trade.valid?
-    #   expect(trade.errors[:item_id]).to include("を入力してください")
-    # end
-    # it "is invalid without a user_id" do
-    #   trade = build(:trade, user_id: nil)
-    #   trade.valid?
-    #   expect(trade.errors[:user_id]).to include("を入力してください")
-    # end
-    # it "is invalid without a address_id" do
-    #   trade = build(:trade, address_id: nil)
-    #   trade.valid?
-    #   expect(trade.errors[:address_id]).to include("を入力してください")
-    # end
-    it "is invalid without a status_num" do
-      trade = build(:trade, status_num: nil)
-      trade.valid?
-      expect(trade.errors[:status_num]).to include("を入力してください")
-    end
-    it "is valid trade" do
-      trade = build(:trade)
-      expect(trade).to be_valid
-    end
+  it "is valid trade" do
+    trade = build(:trade)
+    expect(trade).to be_valid
+  end
+  it "is invalid without a status_num" do
+    trade = build(:trade, status_num: nil)
+    trade.valid?
+    expect(trade.errors[:status_num]).to include("を入力してください")
   end
 end


### PR DESCRIPTION
### Why

商品を購入するにはユーザーがサインインしている必要があり、
カード情報とアドレス情報の両方が必要であるため。

テストコードでは、belong_toのテストのほかに
has_manyのテストをする必要があるため。

tradeモデルのテストでは、belongs_to で定義している外部キー(null不可)に
必須入力のバリデーションを定義すると、RSpecでエラーになってしまうため。

### What

購入画面へ行くために、商品詳細画面でユーザーのサインイン判定を追加しました。
また、購入画面では、購入ボタンを表示／非表示にする処理を追加しました。
ビューで判定するのですが、変数名をそのまま扱うたと可読性が下がるので、
ヘルパーで制御をしています。

PayJpでテストカードを使用している限りでは、カード情報が１つしか
登録できないため、クレジットカード情報の変更画面へのリンクは削除しました。

has_manyのテストコードはaddressnモデルで一対多にある 
itemモデルとtradeモデルのテストをしています。

tradeモデルについては、belongs_toの外部キーに対しては
バリデーションでの必須入力チェックを除外して、失敗テストも削除しました。
