### PR TITLE
購入済み商品の再購入防止と商品表示の微修正。

### DIFF
--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -2,7 +2,8 @@ class TopsController < ApplicationController
   def index
     @brands = Brand.order("RAND()").limit(1)
     id = @brands.ids
-    @items = Item.order('items.created_at desc').limit(3)
+    # @items = Item.order('items.created_at desc').limit(3)
+    @items = Item.for_sale_only.order('items.created_at desc').limit(3)
     @items_brands = Item.where(brand_id: id).order('items.created_at desc').limit(3)
   end
 end

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -2,7 +2,6 @@ class TopsController < ApplicationController
   def index
     @brands = Brand.order("RAND()").limit(1)
     id = @brands.ids
-    # @items = Item.order('items.created_at desc').limit(3)
     @items = Item.for_sale_only.order('items.created_at desc').limit(3)
     @items_brands = Item.where(brand_id: id).order('items.created_at desc').limit(3)
   end

--- a/app/controllers/trades_controller.rb
+++ b/app/controllers/trades_controller.rb
@@ -1,6 +1,6 @@
 class TradesController < ApplicationController
   protect_from_forgery except: [:create]
-  before_action :get_item, :get_card, only: [:index, :new, :create, :fail]
+  before_action :get_item, :get_card, :get_trade, only: [:index, :new, :create, :fail]
 
   def index
 
@@ -52,6 +52,10 @@ class TradesController < ApplicationController
       customer = Payjp::Customer.retrieve(card.customer_id)
       @default_card_information = customer.cards.retrieve(card.card_id)
     end
+  end
+
+  def get_trade
+    @trade = Trade.find_by(user_id: current_user.id, item_id: params[:item_id])
   end
 
   def get_params

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -10,7 +10,7 @@ module ItemsHelper
 
   def thousands_separator(price)
     # 現状はJPY固定。
-    number_to_currency(price, unit: "￥", strip_insignificant_zeros: true)
+    number_to_currency(price, format: "%u%n", unit: "￥", strip_insignificant_zeros: true)
   end
 
 end

--- a/app/helpers/trades_helper.rb
+++ b/app/helpers/trades_helper.rb
@@ -1,7 +1,13 @@
 module TradesHelper
 
+  # 購入者チェック（カード情報と住所があれば購入できる）
   def card_present_and_addres_present?
     @default_card_information.present? && @address.present?
+  end
+
+  # 売約済みチェック（tradeレコードがあれば売約済み）
+  def trade_submited?
+    @trade.present?
   end
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,4 +18,11 @@ class Item < ApplicationRecord
   enum condition_num:{ brand_new: 0, near_new: 1, no_dirt: 2, near_dirt:3 ,dirty:4, bad_condition:5 }
   enum daystoship_num:{one_to_two: 0, two_to_three:1, four_to_seven:2 }
   enum status_num:{exhibit: 0, sold_out:1, finished:2 }
+
+  # scope
+  # 出品中の商品のみを抽出するscope。
+  scope :for_sale_only, -> {
+    left_outer_joins(:trades).where(trades: {id: nil})
+  }
+
 end

--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -5,9 +5,6 @@ class Trade < ApplicationRecord
   belongs_to    :address
 
   # validations
-  # 外部キー(null: false)をvalidationに定義すると、RSpecで正常動作テストで失敗するので、
-  # 解決するまで外部キーを除外する。
-  # validates :item_id, :user_id, :address_id, :status_num, presence: true
   validates :status_num, presence: true
 
   # enum

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -100,7 +100,7 @@
                     .tops-index-content-picup-list-body__details  
                       %ul
                         %li
-                          = item.price
+                          = thousands_separator(item.price)
                       %p (税込)
 
   = render 'layouts/tertiarybanner'

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -78,7 +78,7 @@
                     .tops-index-content-picup-list-body__details  
                       %ul
                         %li
-                          = item.price
+                          = thousands_separator(item.price)
                       %p (税込)
     .tops-index-content-picups
       .tops-index-content-picup

--- a/app/views/trades/new.html.haml
+++ b/app/views/trades/new.html.haml
@@ -72,7 +72,14 @@
                     = @address.number 
                     %br/
                     = @address.building 
-            - if card_present_and_addres_present?
-              .trades-new-buy-content
-                = button_tag "購入する"
+            .trades-new-buy-content
+              - if trade_submited?
+                %span.trades-new-buy-alreay-submited
+                  この商品は売約済みです。
+                .trades-create-buy-content-inner
+                  = link_to root_path do
+                    = button_tag "戻る", class: "trades-create-buy-content-inner__rootbtn"
+              - elsif card_present_and_addres_present?
+                .trades-create-buy-content-inner
+                  = submit_tag "購入する", class: "trades-create-buy-content-inner__submit"
   %footer.trades-new-footer


### PR DESCRIPTION
### why
ショッピングサイトを構築において、対応が必須であるため。

### what
次の対応をしました。

1. 購入後の商品で購入画面へ移動してしまっても、商品が購入できないように対応。
　urlを直接叩いて画面を表示しても購入できないようにした。
[![Screenshot from Gyazo](https://gyazo.com/886ce3690f8b35390fb11d2043029a86/raw)](https://gyazo.com/886ce3690f8b35390fb11d2043029a86)

1. トップページでは出品中の商品のみを表示するように修正。

1. 金額の表記揺れを「¥ 10,000」となるように矯正。

[![Screenshot from Gyazo](https://gyazo.com/d123f918782b12704fad84c1c3e4282a/raw)](https://gyazo.com/d123f918782b12704fad84c1c3e4282a)
[![Screenshot from Gyazo](https://gyazo.com/a251401d0632499480b232283165d889/raw)](https://gyazo.com/a251401d0632499480b232283165d889)
[![Screenshot from Gyazo](https://gyazo.com/9b9d6ec1b07f913347dc1c3e8d6c98f0/raw)](https://gyazo.com/9b9d6ec1b07f913347dc1c3e8d6c98f0)

