### PR TITLE
商品詳細ページの再修正

### DIFF
--- a/app/assets/stylesheets/modules/_items-show.scss
+++ b/app/assets/stylesheets/modules/_items-show.scss
@@ -1,8 +1,36 @@
+.items-show{
+  &__main{
+    background-color: rgb(245, 245, 245);
+    padding:40px;
+  }
+}
+
 .items-show-container{
   width:700px;
   margin:0 auto;
+  background-color: rgb(255, 255, 255);
 }
 .items-show-summary{
+  padding:40px;
+  &__name{
+    text-align: center;
+    font-weight: bold;
+    font-size: 24px;
+  }
+  &__price{
+    margin: 24px 0 24px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    font-size: 46px;
+    font-weight: bold;
+    &--detail{
+      font-size: 16px;      
+    }
+  }
+  &__body{
+    margin-top:16px;
+  }
   &__main-image{
     height:346px;
   }
@@ -15,7 +43,10 @@
   }
 }
 .items-show-detail{
-  width:700px;
+
+  &__container{
+    padding:40px;
+  }
   &__table{
     border-collapse: collapse;
     border-spacing: 0;
@@ -23,20 +54,18 @@
     vertical-align: middle;
     border-color: inherit;
     &--table{
-      width: 100%;
+      width: 620px;
       height: 375px;
       border-collapse: collapse;
-      border: 1px solid #f8f8f8;
+      border: 1px solid rgb(245, 245, 245);
     }
     &--tbody{
       display: table-row-group;
       vertical-align: middle;
-      border-color: inherit;
     }
     &--tr{
       display: table-row;
-      vertical-align: inherit;
-      border-color: inherit;
+      vertical-align: middle;
     }
     &--th{
       font-style: normal;
@@ -47,6 +76,7 @@
       border: 1px solid #dedede;
       font-size: 14px;
       text-align: center;
+      vertical-align: middle;
     }
     &--td{
       width: 61%;
@@ -54,13 +84,14 @@
       border: 1px solid #dedede;
       font-size: 14px;
       display: table-cell;
-      vertical-align: inherit;
     }
   }
 }
 .items-show-other{
   display:flex;
   justify-content: space-between;
+  padding:0 40px;
+  margin:20px 0;
   &__favorite{
     &--btn{
       margin-right: auto;
@@ -82,7 +113,9 @@
   }
 }
 .items-show-comment{
+  padding:40px;
   &__submit{
+    margin:20px 0;
     &--btn{
       display:block;
       margin:0 auto;
@@ -95,16 +128,55 @@
       border-radius: 100px;
     }
   }
+  &__text-area{
+    width: 100%;
+    min-height: 104px;
+    padding: 10px;
+  }
+  &__notify{
+    padding: 8px;
+    font-size: 14px;
+    background-color: rgb(245, 245, 245);
+    margin: 10px 0;
+    text-align: left;
+  }
 }
 .items-show-links{
+  width:700px;
+  margin:20px auto;
   display:flex;
   justify-content: space-between;
+  &__link{
+    color:#3CCACE;
+  }
 }
-
+.items-show-related{
+  color:#3CCACE;
+  width:700px;
+  margin:20px auto;
+  display:flex;
+  justify-content: space-between;
+  &__link{
+    font-weight: bold;
+    font-size: 22px;
+    color:#3CCACE;
+  }
+}
 .items-show-button{
   width:700px;
   display:flex;
   justify-content: space-between;
+  &__sold-out{
+    margin:0 auto;
+    text-align: center;
+    font-size: 18px;
+    line-height: 48px;
+    background: #ea352d;
+    border: 1px solid #ea352d;
+    width: 30%;
+    border-radius: 100px;
+    color: #fff;
+  }
   &__edit{
     margin:0 auto;
     text-align: center;

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -10,7 +10,6 @@ module ItemsHelper
 
   def thousands_separator(price)
     # 現状はJPY固定。
-    number_to_currency(price, unit: "￥", strip_insignificant_zeros: true)
+    number_to_currency(price,format: "%u%n", unit: "￥", strip_insignificant_zeros: true)
   end
-
 end

--- a/app/helpers/trades_helper.rb
+++ b/app/helpers/trades_helper.rb
@@ -1,7 +1,12 @@
 module TradesHelper
 
+  # 購入者チェック（カード情報と住所があれば購入できる）
   def card_present_and_addres_present?
     @default_card_information.present? && @address.present?
   end
-
+  
+  # 売約済みチェック（tradeレコードがあれば売約済み）
+  def trade_submited?
+    @trade.present?
+  end
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -27,64 +27,71 @@
                     送料込み
                   - else
                     送料別
+            .items-show-summary__description
+              = @item.description
           .items-show-detail
-            = @item.title
-          .items-show-detail__table
-            %table.items-show-detail__table--table
-              %tbody.items-show-detail__table--tbody
-                %tr.items-show-detail__table--tr
-                  %th.items-show-detail__table--th
-                    出品者
-                  %td.items-show-detail__table--td
-                    = @item.user.nickname
-                %tr.items-show-detail__table--tr
-                  %th.items-show-detail__table--th
-                    カテゴリー
-                  %td.items-show-detail__table--td
-                    = link_to @item.category.parent.parent.name,'#'
-                    %br/
-                    = link_to @item.category.parent.name,'#'
-                    %br/
-                    = link_to @item.category.name,'#'
-                %tr.items-show-detail__table--tr
-                  %th.items-show-detail__table--th
-                    ブランド
-                  %td.items-show-detail__table--td
-                    - if @item.brand
-                      = @item.brand.name
-                %tr.items-show-detail__table--tr
-                  %th.items-show-detail__table--th 商品のサイズ
-                  %td.items-show-detail__table--td
-                    - if @item.product_size
-                      = @item.product_size.name
-                %tr.items-show-detail__table--tr
-                  %th.items-show-detail__table--th 商品の状態
-                  %td.items-show-detail__table--td
-                    = @item.condition_num_i18n
-                %tr.items-show-detail__table--tr
-                  %th.items-show-detail__table--th 配送料の負担
-                  %td.items-show-detail__table--td
-                    = @item.shippingway.parent.name
-                %tr.items-show-detail__table--tr
-                  %th.items-show-detail__table--th 発送元の地域
-                  %td.items-show-detail__table--td
-                    = link_to @item.address.area.name,'#'
-                %tr.items-show-detail__table--tr
-                  %th.items-show-detail__table--th 発送日の目安
-                  %td.items-show-detail__table--td
-                    = @item.daystoship_num_i18n
+            %h2.items-show-summary__name
+              = @item.title
+            .items-show-detail__container
+              .items-show-detail__table
+                %table.items-show-detail__table--table
+                  %tbody.items-show-detail__table--tbody
+                    %tr.items-show-detail__table--tr
+                      %th.items-show-detail__table--th
+                        出品者
+                      %td.items-show-detail__table--td
+                        = @item.user.nickname
+                    %tr.items-show-detail__table--tr
+                      %th.items-show-detail__table--th
+                        カテゴリー
+                      %td.items-show-detail__table--td
+                        = link_to @item.category.parent.parent.name,'#'
+                        %br/
+                        = link_to @item.category.parent.name,'#'
+                        %br/
+                        = link_to @item.category.name,'#'
+                    %tr.items-show-detail__table--tr
+                      %th.items-show-detail__table--th
+                        ブランド
+                      %td.items-show-detail__table--td
+                        - if @item.brand
+                          = @item.brand.name
+                    %tr.items-show-detail__table--tr
+                      %th.items-show-detail__table--th 商品のサイズ
+                      %td.items-show-detail__table--td
+                        - if @item.product_size
+                          = @item.product_size.name
+                    %tr.items-show-detail__table--tr
+                      %th.items-show-detail__table--th 商品の状態
+                      %td.items-show-detail__table--td
+                        = @item.condition_num_i18n
+                    %tr.items-show-detail__table--tr
+                      %th.items-show-detail__table--th 配送料の負担
+                      %td.items-show-detail__table--td
+                        = @item.shippingway.parent.name
+                    %tr.items-show-detail__table--tr
+                      %th.items-show-detail__table--th 発送元の地域
+                      %td.items-show-detail__table--td
+                        = link_to @item.address.area.name,'#'
+                    %tr.items-show-detail__table--tr
+                      %th.items-show-detail__table--th 発送日の目安
+                      %td.items-show-detail__table--td
+                        = @item.daystoship_num_i18n
           .items-show-button
-            - if user_signed_in? && @item.user_id == current_user.id
-              .items-show-button__edit
-                = link_to '編集する', edit_item_path(@item.id),class:"items-show-button__edit--link"
-              .items-show-button__cancel
-                = link_to '出品を取り消す', item_path(@item.id),method: :delete,class:"items-show-button__cancel--link", data: { confirm: '出品を取り消します。よろしいですか？' }
+            - if @item.trades.present?
+              .items-show-button__sold-out 売り切れ御免
             - else
-              .items-show-button__purchase
-                - if user_signed_in?
-                  = link_to '購入する', new_item_trade_path(@item.id) ,class:"items-show-button__purchase--link"
-                - else
-                  = link_to 'ログイン', new_user_session_path, class:"items-show-button__purchase--link"
+              - if user_signed_in? && @item.user_id == current_user.id
+                .items-show-button__edit
+                  = link_to '編集する', edit_item_path(@item.id),class:"items-show-button__edit--link"
+                .items-show-button__cancel
+                  = link_to '出品を取り消す', item_path(@item.id),method: :delete,class:"items-show-button__cancel--link", data: { confirm: '出品を取り消します。よろしいですか？' }
+              - else
+                .items-show-button__purchase
+                  - if user_signed_in?
+                    = link_to '購入する', new_item_trade_path(@item.id) ,class:"items-show-button__purchase--link"
+                  - else
+                    = link_to 'ログイン', new_user_session_path, class:"items-show-button__purchase--link"
           .items-show-other
             %ul.items-show-other__favorite
               %li.items-show-other__favorite--btn
@@ -100,7 +107,7 @@
         .items-show-comments
           .items-show-comment
             = form_with(model:@comment,local:true) do |f|
-              = f.text_area :comment
+              = f.text_area :comment ,class:"items-show-comment__text-area"
               %p.items-show-comment__notify
                 相手のことを考え丁寧なコメントを心がけましょう。
                 %br/
@@ -111,19 +118,20 @@
                   %i.items-show-comment__submit--icon
                     = icon('fa','comment')
                     コメントする
-      %ul.items-show-links
-        %li
-          = link_to "#" do
-            %i.fa.fa-angle-left
-            %span
-            前の商品
-        %li
-          = link_to "#" do
-            %span 後ろの商品
-            %i.fa.fa-angle-right
-      .items-show-related
-        = link_to 'ベビー・キッズをもっと見る',"#" 
-        .productLists
+    %ul.items-show-links
+      %li
+        = link_to "#",class:"items-show-links__link" do
+          %i.fa.fa-angle-left
+          %span
+          前の商品
+      %li
+        = link_to "#",class:"items-show-links__link" do
+          %span 後ろの商品
+          %i.fa.fa-angle-right
+    .items-show-related
+      = link_to 'ベビー・キッズをもっと見る',"#",class:"items-show-related__link"
+      .items-show-related__productLists
+  = render 'layouts/tertiarybanner'
   %footer.items-show__footer
     = render 'layouts/footer'
   = render 'layouts/purchase-btn'

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -78,7 +78,7 @@
                     .tops-index-content-picup-list-body__details  
                       %ul
                         %li
-                          = item.price
+                          = thousands_separator(item.price)
                       %p (税込)
     .tops-index-content-picups
       .tops-index-content-picup


### PR DESCRIPTION
#why
登録した商品の詳細を表示し、以下ができるよう表示を変更する必要があるため。
・登録したユーザで編集、削除
・他ユーザで購入
・売約済みアイテみは売約済みであることがわかる

#what
・登録ユーザで閲覧した場合は編集、削除ボタンが表示されていること。
・未売約の商品を閲覧した場合は他ユーザで購入ボタンが表示されていること。
・売約済み商品を閲覧した場合は売約済みのボタンが表示されていること。

商品詳細
[![Screenshot from Gyazo](https://gyazo.com/bef130780eb30eb34fc9d375f56dafbd/raw)](https://gyazo.com/bef130780eb30eb34fc9d375f56dafbd)
他ユーザでみた場合
[![Screenshot from Gyazo](https://gyazo.com/33e26510a4236d50f8472b53258b3aac/raw)](https://gyazo.com/33e26510a4236d50f8472b53258b3aac)
商品購入後
[![Screenshot from Gyazo](https://gyazo.com/705dddde7bc9ad72f331c9d2afd0c721/raw)](https://gyazo.com/705dddde7bc9ad72f331c9d2afd0c721)