### PR TITLE
購入機能 form_tag から form_with へ変更

### DIFF
--- a/app/controllers/trades_controller.rb
+++ b/app/controllers/trades_controller.rb
@@ -14,7 +14,6 @@ class TradesController < ApplicationController
     #支払い処理
     card = Creditcard.find_by(user_id: current_user.id)
     Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
-    binding.pry
     pay = Payjp::Charge.create(
       :amount => @item.price.to_i, #decimalをintegerに変換
       :customer => card.customer_id, #顧客ID 

--- a/app/controllers/trades_controller.rb
+++ b/app/controllers/trades_controller.rb
@@ -50,7 +50,7 @@ class TradesController < ApplicationController
   end
 
   def get_trade
-    @trade = Trade.find_by(user_id: current_user.id, item_id: params[:item_id])
+    @trade = Trade.find_by(item_id: params[:item_id])
     if @trade.nil?
       @trade = Trade.new
       @trade.user_id = current_user.id

--- a/app/helpers/trades_helper.rb
+++ b/app/helpers/trades_helper.rb
@@ -1,7 +1,7 @@
 module TradesHelper
 
   # 購入者チェック（カード情報と住所があれば購入できる）
-  def card_present_and_addres_present?(card, address)
+  def card_present_and_address_present?(card, address)
     card.present? && address.present?
   end
 

--- a/app/helpers/trades_helper.rb
+++ b/app/helpers/trades_helper.rb
@@ -1,13 +1,13 @@
 module TradesHelper
 
   # 購入者チェック（カード情報と住所があれば購入できる）
-  def card_present_and_addres_present?
-    @default_card_information.present? && @address.present?
+  def card_present_and_addres_present?(card, address)
+    card.present? && address.present?
   end
 
   # 売約済みチェック（tradeレコードがあれば売約済み）
-  def trade_submited?
-    @trade.present?
+  def trade_submited?(trade)
+    trade.present?
   end
 
 end

--- a/app/helpers/trades_helper.rb
+++ b/app/helpers/trades_helper.rb
@@ -5,9 +5,9 @@ module TradesHelper
     card.present? && address.present?
   end
 
-  # 売約済みチェック（tradeレコードがあれば売約済み）
+  # 売約済みチェック（trade_idがあれば売約済み）
   def trade_submited?(trade)
-    trade.present?
+    trade.id.present?
   end
 
 end

--- a/app/views/trades/new.html.haml
+++ b/app/views/trades/new.html.haml
@@ -21,7 +21,7 @@
       .trades-new-buy-content
         .trades-new-buy-content-inner
           -# 購入機能を実装させるために、まずはform_tagにて実装をする。 今後はform_withへ移行する。
-          = form_tag(action: :create, method: :post) do
+          = form_with(model: [@item, @trade], method: item_trades_path(@item.id), local: true) do |f|
             %ul.trades-new-buy-price-table
               %li.trades-new-buy-price-table__row
                 .trades-new-buy-price-table__cell--label 支払い金額

--- a/app/views/trades/new.html.haml
+++ b/app/views/trades/new.html.haml
@@ -20,66 +20,71 @@
                   %span.trades-new-buy-item__shipping-fee （税込）送料込み
       .trades-new-buy-content
         .trades-new-buy-content-inner
-          -# 購入機能を実装させるために、まずはform_tagにて実装をする。 今後はform_withへ移行する。
-          = form_with(model: [@item, @trade], method: item_trades_path(@item.id), local: true) do |f|
-            %ul.trades-new-buy-price-table
-              %li.trades-new-buy-price-table__row
-                .trades-new-buy-price-table__cell--label 支払い金額
-                .trades-new-buy-price-table__cell
-                  %span
-                    = thousands_separator(@item.price)
-            .trades-new-buy-content
-              .trades-new-buy-content-inner
-                %h3 支払い方法
-                - if @default_card_information.nil?
-                  = link_to  new_user_creditcard_path(current_user.id), class: "trades-new-buy-user-info-fix" do
+          - if trade_submited?(@trade)
+            %span.trades-new-buy-alreay-submited
+              この商品は売約済みです。
+            .trades-create-buy-content-inner
+              = link_to root_path do
+                = button_tag "戻る", class: "trades-create-buy-content-inner__rootbtn"
+          - else
+            = form_with(model: [@item, @trade],  local: true) do |f|
+              %ul.trades-new-buy-price-table
+                %li.trades-new-buy-price-table__row
+                  .trades-new-buy-price-table__cell--label 支払い金額
+                  .trades-new-buy-price-table__cell
+                    %span
+                      = thousands_separator(@item.price)
+              .trades-new-buy-content
+                .trades-new-buy-content-inner
+                  %h3 支払い方法
+                  - if @default_card_information.nil?
+                    = link_to new_user_creditcard_path(current_user.id), class: "trades-new-buy-user-info-fix" do
+                      %p.trades-new-buy-user-info-text__cardinfo
+                        .trades-new-icon-plus-circle
+                          = icon('fas', 'plus-circle')
+                          %span.trades-new-buy-register-text--new
+                            登録してください
+                  - else
                     %p.trades-new-buy-user-info-text__cardinfo
-                      .trades-new-icon-plus-circle
-                        = icon('fas', 'plus-circle')
-                        %span.trades-new-buy-register-text--new
-                          登録してください
-                - else
-                  %p.trades-new-buy-user-info-text__cardinfo
-                    .creditcards-show-confirmation__contents
-                      .creditcards-show-confirmation__card-number
-                        .creditcards-show-confirmation__card-number--text カード番号
-                        .creditcards-show-confirmation__card-number--number
-                          = "**** **** **** " + @default_card_information.last4
-                      .creditcards-show-confirmation__expire
-                        .creditcards-show-confirmation__expire--text 有効期限
-                        .creditcards-show-confirmation__expire--date
-                          - exp_month = @default_card_information.exp_month.to_s
-                          - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
-                          = exp_month + " 月 / " + exp_year + " 年"
-            .trades-new-buy-content
-              .trades-new-buy-content-inner
-                %h3 配送先
-                - if @address.nil?
-                  = link_to new_user_address_path(current_user.id), class: "trades-new-buy-user-info-fix" do
-                    %p.trades-new-buy-user-info-text
-                      .trades-new-icon-plus-circle
-                        = icon('fas', 'plus-circle')
-                        %span.trades-new-buy-register-text 登録してください
-                - else
-                  = link_to edit_user_address_path(current_user.id, @address.id), class: "trades-new-buy-user-info-fix" do
-                    %span.trades-new-buy-register-text--edit
-                      変更する
-                  %p.trades-new-buy-user-info-text__addressinfo
-                    = @address.postal_number 
-                    %br/
-                    = @address.city 
-                    %br/
-                    = @address.number 
-                    %br/
-                    = @address.building 
-            .trades-new-buy-content
-              - if trade_submited?(@trade)
-                %span.trades-new-buy-alreay-submited
-                  この商品は売約済みです。
-                .trades-create-buy-content-inner
-                  = link_to root_path do
-                    = button_tag "戻る", class: "trades-create-buy-content-inner__rootbtn"
-              - elsif card_present_and_addres_present?(@default_card_information, @address)
-                .trades-create-buy-content-inner
-                  = submit_tag "購入する", class: "trades-create-buy-content-inner__submit"
+                      .creditcards-show-confirmation__contents
+                        .creditcards-show-confirmation__card-number
+                          .creditcards-show-confirmation__card-number--text カード番号
+                          .creditcards-show-confirmation__card-number--number
+                            = "**** **** **** " + @default_card_information.last4
+                        .creditcards-show-confirmation__expire
+                          .creditcards-show-confirmation__expire--text 有効期限
+                          .creditcards-show-confirmation__expire--date
+                            - exp_month = @default_card_information.exp_month.to_s
+                            - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+                            = exp_month + " 月 / " + exp_year + " 年"
+              .trades-new-buy-content
+                .trades-new-buy-content-inner
+                  %h3 配送先
+                  - if @address.nil?
+                    = link_to new_user_address_path(current_user.id), class: "trades-new-buy-user-info-fix" do
+                      %p.trades-new-buy-user-info-text
+                        .trades-new-icon-plus-circle
+                          = icon('fas', 'plus-circle')
+                          %span.trades-new-buy-register-text 登録してください
+                  - else
+                    = link_to edit_user_address_path(current_user.id, @address.id), class: "trades-new-buy-user-info-fix" do
+                      %span.trades-new-buy-register-text--edit
+                        変更する
+                    %p.trades-new-buy-user-info-text__addressinfo
+                      = @address.postal_number 
+                      %br/
+                      = @address.city 
+                      %br/
+                      = @address.number 
+                      %br/
+                      = @address.building 
+              .trades-new-buy-content
+                .trades-new-buy-content-inner
+                  = f.hidden_field :user_id
+                  = f.hidden_field :item_id
+                  = f.hidden_field :address_id
+                .trades-new-buy-content
+                - if card_present_and_addres_present?(@default_card_information, @address)
+                  .trades-create-buy-content-inner
+                    = submit_tag "購入する", class: "trades-create-buy-content-inner__submit"
   %footer.trades-new-footer

--- a/app/views/trades/new.html.haml
+++ b/app/views/trades/new.html.haml
@@ -84,7 +84,7 @@
                   = f.hidden_field :item_id
                   = f.hidden_field :address_id
                 .trades-new-buy-content
-                - if card_present_and_addres_present?(@default_card_information, @address)
+                - if card_present_and_address_present?(@default_card_information, @address)
                   .trades-create-buy-content-inner
                     = submit_tag "購入する", class: "trades-create-buy-content-inner__submit"
   %footer.trades-new-footer

--- a/app/views/trades/new.html.haml
+++ b/app/views/trades/new.html.haml
@@ -73,13 +73,13 @@
                     %br/
                     = @address.building 
             .trades-new-buy-content
-              - if trade_submited?
+              - if trade_submited?(@trade)
                 %span.trades-new-buy-alreay-submited
                   この商品は売約済みです。
                 .trades-create-buy-content-inner
                   = link_to root_path do
                     = button_tag "戻る", class: "trades-create-buy-content-inner__rootbtn"
-              - elsif card_present_and_addres_present?
+              - elsif card_present_and_addres_present?(@default_card_information, @address)
                 .trades-create-buy-content-inner
                   = submit_tag "購入する", class: "trades-create-buy-content-inner__submit"
   %footer.trades-new-footer


### PR DESCRIPTION
### why

rails 5.2 以降のバージョンでは、formのヘルパーメソッドは
「form_with」が推奨されているため。

### what

購入済の場合は、foamを生成しないように修正しました。
さらに、form_tagからform_withへ変更しました。
ただし、form内に渡しているのは、tradeテーブルの外部キー
(user_id, item_id, address_id)
のみとなっています。

価格やカード情報をfoam内に取り込んで、
購入ボタンでストロングパラメータでPOSTすることも考えましたが、

itemモデルやcardモデルのデータでもparamsで参照するrequireが「trade」となってしまうため
保留としました。
