### PR TITLE
購入機能 多重購入防止機能の追加実装(item_idをUniqueにする)

### DIFF
--- a/db/migrate/20200321063638_modify_column_item_id_to_trades.rb
+++ b/db/migrate/20200321063638_modify_column_item_id_to_trades.rb
@@ -1,0 +1,15 @@
+class ModifyColumnItemIdToTrades < ActiveRecord::Migration[5.2]
+  def up
+    remove_foreign_key(:trades, :items)
+    remove_index(:trades, name: :index_trades_on_item_id)
+    add_index(:trades, :item_id, unique: true)
+    add_foreign_key(:trades, :items)
+  end
+
+  def down
+    remove_foreign_key(:trades, :items)
+    remove_index(:trades, name: :index_trades_on_item_id)
+    add_index(:trades, :item_id)
+    add_foreign_key(:trades, :items)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_03_102404) do
+ActiveRecord::Schema.define(version: 2020_03_21_063638) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -132,7 +132,7 @@ ActiveRecord::Schema.define(version: 2020_03_03_102404) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["address_id"], name: "index_trades_on_address_id"
-    t.index ["item_id"], name: "index_trades_on_item_id"
+    t.index ["item_id"], name: "index_trades_on_item_id", unique: true
     t.index ["user_id"], name: "index_trades_on_user_id"
   end
 


### PR DESCRIPTION
### Why 

同じ商品(item)を複数回購入させないようにするため。

### What

前回の対応では、購入済みの商品を出品一覧から表示させないように対応
しましたが、tradesテーブルのitemi_idにUnique制約をつけてなかったので
追加しました。
