### PR TITLE
購入機能 成功テストと失敗テストの実装

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,7 +11,7 @@ class Item < ApplicationRecord
 
   belongs_to    :user
   belongs_to    :address
-  has_many      :trades
+  has_one       :trade
   
 
   # enum

--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -5,8 +5,8 @@ class Trade < ApplicationRecord
   belongs_to    :address
 
   # validations
-  validates :item_id, :user_id, :address_id, :status_num, presence: true
-
+  validates :user_id, :address_id, :status_num, presence: true
+  validates :item_id, presence: true, uniqueness: true
   # enum
   enum status_num:{trading:0, under_delivery:1, finished:2 }
 end

--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -5,7 +5,7 @@ class Trade < ApplicationRecord
   belongs_to    :address
 
   # validations
-  validates :status_num, presence: true
+  validates :item_id, :user_id, :address_id, :status_num, presence: true
 
   # enum
   enum status_num:{trading:0, under_delivery:1, finished:2 }

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -37,7 +37,7 @@ FactoryBot.define do
   # tradeモデルテスト用 出品者住所
   factory :selladdress, class: Address do
        
-    postal_number    {"123-4567"}
+    postal_number    {"1234567"}
     city             {"city_1"}
     number           {"number_1"}
     building         {"building_1"}
@@ -56,7 +56,7 @@ FactoryBot.define do
   # tradeモデルテスト用 購入者住所
   factory :buyaddress, class: Address do
 
-    postal_number    {"123-4567"}
+    postal_number    {"1234567"}
     city             {"city_2"}
     number           {"number_2"}
     building         {"building_2"}

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
 
   factory :address, class: Address do
 
-    sequence(:city) { |i| "city_#{i}"}
-    sequence(:number) { |i| "number_#{i}"}
+    sequence(:city)     { |i| "city_#{i}"}
+    sequence(:number)   { |i| "number_#{i}"}
     sequence(:building) { |i| "building#{i}"}
 
     association :area

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -27,4 +27,42 @@ FactoryBot.define do
 
   end
 
+  # tradeモデルテスト用 出品者住所
+  factory :selladdress, class: Address do
+       
+    postal_number    {"123-4567"}
+    city             {"city_1"}
+    number           {"number_1"}
+    building         {"building_1"}
+    last_name        {"太郎"}
+    first_name       {"出品"}
+    last_name_kana   {"タロウ"}
+    first_name_kana  {"シュッピン"}
+    status_num       {0}
+    telephone_number {"03-1234-5678"}
+
+    association :area
+    association :user, factory: :seller
+
+  end
+
+  # tradeモデルテスト用 購入者住所
+  factory :buyaddress, class: Address do
+
+    postal_number    {"123-4567"}
+    city             {"city_2"}
+    number           {"number_2"}
+    building         {"building_2"}
+    last_name        {"次郎"}
+    first_name       {"購入"}
+    last_name_kana   {"ジロウ"}
+    first_name_kana  {"コウニュウ"}
+    status_num       {0}
+    telephone_number {"03-1234-5678"}
+
+    association :area
+    association :user, factory: :buyer
+
+  end
+
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -11,10 +11,29 @@ FactoryBot.define do
     price            {1000.000}
     feerate          {0.100}
     profit_price     {900.000}
+    user_id
 
     association :user
     association :address
     association :category
+
+  end
+
+  # tradeモデルテスト用
+  factory :sellitem, class: Item do
+
+    sequence(:title) { |i| "product_#{i}"}
+    sequence(:description) { |i| "description_#{i}"}
+
+    condition_num    {0}
+    daystoship_num   {0}
+    price            {1000.000}
+    feerate          {0.100}
+    profit_price     {900.000}
+
+    association :category
+    association :address, factory: :selladdress
+    user             {address.user}
 
   end
 

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -11,7 +11,6 @@ FactoryBot.define do
     price            {1000.000}
     feerate          {0.100}
     profit_price     {900.000}
-    user_id
 
     association :user
     association :address

--- a/spec/factories/trades.rb
+++ b/spec/factories/trades.rb
@@ -3,9 +3,6 @@ FactoryBot.define do
   factory :trade do
 
     status_num  {0}
-    item_id     {1}
-    user_id     {2}
-    address_id  {2}
 
     association :item, factory: :sellitem
     association :address, factory: :buyaddress

--- a/spec/factories/trades.rb
+++ b/spec/factories/trades.rb
@@ -2,11 +2,14 @@ FactoryBot.define do
 
   factory :trade do
 
-    status_num         {0}
+    status_num  {0}
+    item_id     {1}
+    user_id     {2}
+    address_id  {2}
 
-    association :item
-    association :user
-    association :address
+    association :item, factory: :sellitem
+    association :address, factory: :buyaddress
+    user        {address.user}
 
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
 
-  factory :user do
+  factory :user, class: User do
     sequence(:nickname)        { |i| "テスト太郎_#{i}"}
     sequence(:email)           { |i| "kkk_#{i}@gmail.com"}
     password                   {"00000000a"}
@@ -12,4 +12,33 @@ FactoryBot.define do
     birthday                   {"20190101"}
     telephone_number           {"1234567890"}
   end
+
+  # tradeモデルテスト用 出品者 
+  factory :seller, class: User do
+    sequence(:nickname)        { |i| "出品者_#{i}"}
+    sequence(:email)           { |i| "seller_#{i}@test.com"}
+    password                   {"00000000a"}
+    password_confirmation      {"00000000a"}
+    last_name                  {"苗字太郎"}
+    first_name                 {"名前太郎"}
+    last_name_kana             {"ミョウジカナ"}
+    first_name_kana            {"ナマエカナ"}
+    birthday                   {"20190101"}
+    telephone_number           {"1234567890"}
+  end
+
+  # tradeモデルテスト用 購入者 
+  factory :buyer, class: User do
+    sequence(:nickname)        { |i| "購入者_#{i}"}
+    sequence(:email)           { |i| "byuer_#{i}@test.com"}
+    password                   {"00000000a"}
+    password_confirmation      {"00000000a"}
+    last_name                  {"苗字太郎"}
+    first_name                 {"名前太郎"}
+    last_name_kana             {"ミョウジカナ"}
+    first_name_kana            {"ナマエカナ"}
+    birthday                   {"20190101"}
+    telephone_number           {"1234567890"}
+  end
+
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -17,8 +17,8 @@ FactoryBot.define do
   factory :seller, class: User do
     sequence(:nickname)        { |i| "出品者_#{i}"}
     sequence(:email)           { |i| "seller_#{i}@test.com"}
-    password                   {"00000000a"}
-    password_confirmation      {"00000000a"}
+    password                   {"00000000b"}
+    password_confirmation      {"00000000b"}
     last_name                  {"苗字太郎"}
     first_name                 {"名前太郎"}
     last_name_kana             {"ミョウジカナ"}
@@ -31,8 +31,8 @@ FactoryBot.define do
   factory :buyer, class: User do
     sequence(:nickname)        { |i| "購入者_#{i}"}
     sequence(:email)           { |i| "byuer_#{i}@test.com"}
-    password                   {"00000000a"}
-    password_confirmation      {"00000000a"}
+    password                   {"00000000c"}
+    password_confirmation      {"00000000c"}
     last_name                  {"苗字太郎"}
     first_name                 {"名前太郎"}
     last_name_kana             {"ミョウジカナ"}

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
 
   factory :user do
-    nickname              {"テスト太郎"}
-    email                 {"kkk@gmail.com"}
-    password              {"00000000a"}
-    password_confirmation {"00000000a"}
-    last_name             {"苗字太郎"}
-    first_name            {"名前太郎"}
-    last_name_kana        {"ミョウジカナ"}
-    first_name_kana       {"ナマエカナ"}
-    birthday              {"20190101"}
-    telephone_number      {"1234567890"}
+    sequence(:nickname)        { |i| "テスト太郎_#{i}"}
+    sequence(:email)           { |i| "kkk_#{i}@gmail.com"}
+    password                   {"00000000a"}
+    password_confirmation      {"00000000a"}
+    last_name                  {"苗字太郎"}
+    first_name                 {"名前太郎"}
+    last_name_kana             {"ミョウジカナ"}
+    first_name_kana            {"ナマエカナ"}
+    birthday                   {"20190101"}
+    telephone_number           {"1234567890"}
   end
 end

--- a/spec/models/trade_spec.rb
+++ b/spec/models/trade_spec.rb
@@ -2,11 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Trade, type: :model do
   describe "#create" do
-    let(:seller) { create(:user) }
-    let(:item) { create(:item, user_id: seller.id) }
-    let(:buyer) { create(:user) }
-    let(:address) { create(:address, user_id: buyer.id) }
-
+    let(:trade)    { create(:trade) }
     it "is invalid without a item_id" do
       trade = build(:trade, item_id: nil)
       trade.valid?
@@ -28,15 +24,6 @@ RSpec.describe Trade, type: :model do
       expect(trade.errors[:status_num]).to include("を入力してください")
     end
     it "is valid trade" do
-      seller
-      binding.pry
-      item
-      buyer
-      address
-      binding.pry
-      trade = build(:trade, item_id: item.id, user_id: buyre.id, address_id: address.id)
-      trade.valid?
-      binding.pry
       expect(trade).to be_valid
     end
   end

--- a/spec/models/trade_spec.rb
+++ b/spec/models/trade_spec.rb
@@ -1,13 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Trade, type: :model do
-  it "is valid trade" do
-    trade = build(:trade)
-    expect(trade).to be_valid
-  end
-  it "is invalid without a status_num" do
-    trade = build(:trade, status_num: nil)
-    trade.valid?
-    expect(trade.errors[:status_num]).to include("を入力してください")
+  
+  describe "#create" do
+    let(:user) { create(:user) }
+    let(:address) { create(:address, user_id: user.id) }
+    let(:buyer) { create(:user) }
+    let(:item) { create(:item, user_id: buyer.id) }
+    it "is invalid without a item_id" do
+      trade = build(:trade, item_id: nil)
+      trade.valid?
+      expect(trade.errors[:item_id]).to include("を入力してください")
+    end
+    it "is invalid without a user_id" do
+      trade = build(:trade, user_id: nil)
+      trade.valid?
+      expect(trade.errors[:user_id]).to include("を入力してください")
+    end
+    it "is invalid without a address_id" do
+      trade = build(:trade, address_id: nil)
+      trade.valid?
+      expect(trade.errors[:address_id]).to include("を入力してください")
+    end
+    it "is invalid without a status_num" do
+      trade = build(:trade, status_num: nil)
+      trade.valid?
+      expect(trade.errors[:status_num]).to include("を入力してください")
+    end
+    it "is valid trade" do
+      trade = build(:trade)
+      trade.valid?
+      binding.pry
+      expect(trade).to be_valid
+    end
   end
 end

--- a/spec/models/trade_spec.rb
+++ b/spec/models/trade_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe Trade, type: :model do
       trade.valid?
       expect(trade.errors[:status_num]).to include("を入力してください")
     end
+    it "is invalid duplicate a item_id" do
+      trade1 = create(:trade)
+      address2 = create(:buyaddress)
+      user2 = create(:buyer)
+      trade2 = build(:trade, item_id: trade1.item_id, user_id: user2.id, address_id: address2.id)
+      trade2.valid?
+      expect(trade2.errors[:item_id]).to include("はすでに存在します")
+    end
     it "is valid trade" do
       expect(trade).to be_valid
     end

--- a/spec/models/trade_spec.rb
+++ b/spec/models/trade_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Trade, type: :model do
-  
   describe "#create" do
-    let(:user) { create(:user) }
-    let(:address) { create(:address, user_id: user.id) }
+    let(:seller) { create(:user) }
+    let(:item) { create(:item, user_id: seller.id) }
     let(:buyer) { create(:user) }
-    let(:item) { create(:item, user_id: buyer.id) }
+    let(:address) { create(:address, user_id: buyer.id) }
+
     it "is invalid without a item_id" do
       trade = build(:trade, item_id: nil)
       trade.valid?
@@ -28,7 +28,13 @@ RSpec.describe Trade, type: :model do
       expect(trade.errors[:status_num]).to include("を入力してください")
     end
     it "is valid trade" do
-      trade = build(:trade)
+      seller
+      binding.pry
+      item
+      buyer
+      address
+      binding.pry
+      trade = build(:trade, item_id: item.id, user_id: buyre.id, address_id: address.id)
       trade.valid?
       binding.pry
       expect(trade).to be_valid


### PR DESCRIPTION
### Why

エンジニアとして、テストコードの作成は必須のため。

### What 

購入機能(tradeモデル)の成功テストと失敗テストを実装しました。
バリデーションに次のように変更しました。
user_id,address_id,status_numを必須入力としています。
item_idは必須入力と重複不可としています。

user, address, item のfactoryデータは、
tradeモデルのassociationに対応するために新しく追加してあります。

[![Screenshot from Gyazo](https://gyazo.com/3ba4ab1e767316b1e938770cf6520d20/raw)](https://gyazo.com/3ba4ab1e767316b1e938770cf6520d20)