### PR TITLE
出品済みまたは購入済みの住所を削除できないように対応(issue 106の対応)

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,5 +1,6 @@
 class AddressesController < ApplicationController
   before_action :set_address, only: [:edit, :update, :destroy]
+  before_action :must_not_destroy_child_eixts, only: [:destroy]
 
   def index
     @addresses = Address.where(user_id: current_user.id)
@@ -24,8 +25,12 @@ class AddressesController < ApplicationController
   end
 
   def destroy
-    render :index and return unless @address.destroy
-    redirect_to user_addresses_path, notice:"住所を削除しました" if @address.destroy
+    if must_not_destroy_child_eixts
+      render :index and return unless @address.destroy
+      redirect_to user_addresses_path, notice:"住所を削除しました" 
+    else
+      redirect_to user_addresses_path, notice:"出品または購入に利用した住所は削除できません" 
+    end
   end
 
   
@@ -37,4 +42,9 @@ class AddressesController < ApplicationController
   def set_address
     @address = Address.find(params[:id])
   end
+
+  def must_not_destroy_child_eixts
+    return @address.items.empty? && @address.trades.empty?  
+  end
+
 end


### PR DESCRIPTION
### why

出品もしくは購入で使用した住所が削除できてしまうので
削除できないように対応が必要。

### what

addresses_controllerのdestroyアクションにitemとtradeの存在したら
addressを消せないように対応した。

[![Screenshot from Gyazo](https://gyazo.com/8becd5d654dad3a72c3227d45f14006a/raw)](https://gyazo.com/8becd5d654dad3a72c3227d45f14006a)