### PR TITLE
購入済商品がある場合は住所が変更できないようにする(Issue #108の対応)

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,7 +1,7 @@
 class AddressesController < ApplicationController
   before_action :set_address, only: [:edit, :update, :destroy]
-  before_action :must_not_destroy_children_exists, only: [:destroy]
-  before_action :must_not_update_trades_exists, only: [:edit]
+  before_action :address_children_exists?, only: [:destroy]
+  before_action :trades_exists?, only: [:edit]
 
   def index
     @addresses = Address.where(user_id: current_user.id)
@@ -18,7 +18,7 @@ class AddressesController < ApplicationController
   end
 
   def edit
-    if must_not_update_trades_exists
+    if trades_exists?
       redirect_to user_addresses_path, notice: "購入に利用されている住所のため変更できません"
     end
   end
@@ -29,7 +29,7 @@ class AddressesController < ApplicationController
   end
 
   def destroy
-    if must_not_destroy_children_exists
+    if address_children_exists?
       redirect_to user_addresses_path, notice:"出品または購入に利用した住所は削除できません" 
     else
       render :index and return unless @address.destroy
@@ -47,12 +47,12 @@ class AddressesController < ApplicationController
     @address = Address.find(params[:id])
   end
 
-  def must_not_destroy_children_exists
+  def address_children_exists?
     #出品済または購入済ならtrueを返す 
     return @address.items.present? || @address.trades.present?  
   end
 
-  def must_not_update_trades_exists
+  def trades_exists?
     #購入済ならtrueを返す 
     item_ids = @address.items.ids
     return Trade.find_by(item_id: item_ids).present?

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,6 +1,7 @@
 class AddressesController < ApplicationController
   before_action :set_address, only: [:edit, :update, :destroy]
-  before_action :must_not_destroy_child_eixts, only: [:destroy]
+  before_action :must_not_destroy_children_exists, only: [:destroy]
+  before_action :must_not_update_trades_exists, only: [:edit]
 
   def index
     @addresses = Address.where(user_id: current_user.id)
@@ -17,6 +18,9 @@ class AddressesController < ApplicationController
   end
 
   def edit
+    if must_not_update_trades_exists
+      redirect_to user_addresses_path, notice: "購入に利用されている住所のため変更できません"
+    end
   end
 
   def update
@@ -25,11 +29,11 @@ class AddressesController < ApplicationController
   end
 
   def destroy
-    if must_not_destroy_child_eixts
+    if must_not_destroy_children_exists
+      redirect_to user_addresses_path, notice:"出品または購入に利用した住所は削除できません" 
+    else
       render :index and return unless @address.destroy
       redirect_to user_addresses_path, notice:"住所を削除しました" 
-    else
-      redirect_to user_addresses_path, notice:"出品または購入に利用した住所は削除できません" 
     end
   end
 
@@ -43,8 +47,15 @@ class AddressesController < ApplicationController
     @address = Address.find(params[:id])
   end
 
-  def must_not_destroy_child_eixts
-    return @address.items.empty? && @address.trades.empty?  
+  def must_not_destroy_children_exists
+    #出品済または購入済ならtrueを返す 
+    return @address.items.present? || @address.trades.present?  
+  end
+
+  def must_not_update_trades_exists
+    #購入済ならtrueを返す 
+    item_ids = @address.items.ids
+    return Trade.find_by(item_id: item_ids).present?
   end
 
 end


### PR DESCRIPTION
### why

購入後、発送前に住所の改ざんができないようにするため。

### what

編集しようとするアドレスが購入済みであるかを検知して、
存在する場合は編集ができないようにした。

<img width="996" alt="スクリーンショット 2020-04-03 20 04 54" src="https://user-images.githubusercontent.com/57991043/78355964-a4be8300-75e9-11ea-88ad-ef02837522e8.png">

<img width="1005" alt="スクリーンショット 2020-04-03 20 04 00" src="https://user-images.githubusercontent.com/57991043/78355970-a8520a00-75e9-11ea-83e5-9f2b48750984.png">

<img width="998" alt="スクリーンショット 2020-04-03 20 24 04" src="https://user-images.githubusercontent.com/57991043/78355976-aab46400-75e9-11ea-83b1-4c7ae7cdf71f.png">

[![Screenshot from Gyazo](https://gyazo.com/50f12ccb55ec02536306f3383c856ac5/raw)](https://gyazo.com/50f12ccb55ec02536306f3383c856ac5)
