### PR TITLE
購入確認画面のマークアップ 

### DIFF
--- a/app/assets/stylesheets/modules/trades_new.scss
+++ b/app/assets/stylesheets/modules/trades_new.scss
@@ -108,6 +108,24 @@
     color: #3CCACE;
   }
   &__info {
-    padding: 25px 0;
+    padding: 30px 0;
+    line-height: normal;
+  }
+}
+
+/*---戻るボタン---*/
+.trades-create-buy-content-inner {
+  margin: 30px 0;
+  &__rootbtn {
+    margin:0 auto;
+    text-align: center;
+    font-size: 18px;
+    line-height: 48px;
+    background: #3CCACE;
+    border: 1px solid #3CCACE;
+    width: 100%;
+    border-radius: 100px;
+    color: #fff;
+    text-decoration: none;
   }
 }

--- a/app/assets/stylesheets/modules/trades_new.scss
+++ b/app/assets/stylesheets/modules/trades_new.scss
@@ -40,6 +40,12 @@
     height: 100px;
     padding: 32px;
   }
+  &-alreay-submited {
+    color:#ea352d;
+    font-weight: bold;
+    font-size: 25px;
+    letter-spacing: 3.5px;
+  }
 }
 
 /*---商品詳細---*/

--- a/app/assets/stylesheets/modules/trades_new.scss
+++ b/app/assets/stylesheets/modules/trades_new.scss
@@ -17,3 +17,16 @@
     background-color: rgb(255, 255, 255);
   }
 }
+
+.trades-new-buy-content {
+  padding: 32px 16px;
+  border-top: 1px solid #f5f5f5;
+  &-inner {
+    max-width: 343px;
+    margin: 0 auto;
+    h3 {
+      float: left;
+      font-size: 16px;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/trades_new.scss
+++ b/app/assets/stylesheets/modules/trades_new.scss
@@ -41,3 +41,26 @@
     padding: 32px;
   }
 }
+
+/*---商品詳細---*/
+.trades-new-buy-item {
+  &-box{
+    display: flex;
+  }
+  &__image {
+    display: flex;
+  }
+  &__detail {
+    margin-left: 30px;
+    &--name {
+      font-size: 14px;
+      padding: 0 0 8px;
+      line-height: 1.5;
+      text-align: left;
+    }
+  }
+  &__price-ja {
+    padding-top: 20px;
+    font-size: 15px;
+  }
+}

--- a/app/assets/stylesheets/modules/trades_new.scss
+++ b/app/assets/stylesheets/modules/trades_new.scss
@@ -11,28 +11,9 @@
       width: 200px;
     }
   }
-}
-
-.trades-new-buy {
-/*---購入内容の確認---*/
-  &__head {
-    text-align: center;
-    font-weight: bold;
-    font-size: 24px;
-    height: 100px;
-    padding: 32px;
-  }
-
-  &-content {
-    padding: 32px 16px;
-    border-top: 1px solid #f5f5f5;
-      &-inner{
-      max-width: 343px;
-      margin: 0 auto;
-        h3 {
-          float: left;
-          font-size: 16px;
-        }
-      }
+  &-container {
+    width:700px;
+    margin:0 auto;
+    background-color: rgb(255, 255, 255);
   }
 }

--- a/app/assets/stylesheets/modules/trades_new.scss
+++ b/app/assets/stylesheets/modules/trades_new.scss
@@ -30,3 +30,14 @@
     }
   }
 }
+
+/*---購入内容の確認---*/
+.trades-new-buy {
+  &__head {
+    text-align: center;
+    font-weight: bold;
+    font-size: 24px;
+    height: 100px;
+    padding: 32px;
+  }
+}

--- a/app/assets/stylesheets/modules/trades_new.scss
+++ b/app/assets/stylesheets/modules/trades_new.scss
@@ -26,6 +26,7 @@
     margin: 0 auto;
     h3 {
       float: left;
+      font-weight: bold;
       font-size: 16px;
     }
   }
@@ -76,14 +77,26 @@
   margin: 20px 0;
   display: table;
   border-collapse: collapse;
-  font-size: 20px;
   width: 100%;
+  span {
+    font-size: 22px;
+  }
   &__row {
     display: table-row;
   }
   &__cell {
     display: table-cell;
-    text-align: center;
-    padding: 0;
+    text-align: right;
+  }
+}
+
+/*---支払方法---*/
+.trades-new-cash {
+  margin: 30px 0;
+  padding: 20px 0;
+  border-top: 1px solid #f5f5f5;
+  &__icon {
+    float: right;
+    color: #3CCACE;
   }
 }

--- a/app/assets/stylesheets/modules/trades_new.scss
+++ b/app/assets/stylesheets/modules/trades_new.scss
@@ -27,7 +27,6 @@
     h3 {
       float: left;
       font-weight: bold;
-      font-size: 16px;
     }
   }
 }
@@ -41,6 +40,7 @@
     height: 100px;
     padding: 32px;
   }
+/*---売約済み---*/
   &-alreay-submited {
     margin-bottom: 24px;
     &__text {
@@ -54,7 +54,7 @@
 
 /*---商品詳細---*/
 .trades-new-buy-item {
-  &-box{
+  &-box {
     display: flex;
   }
   &__image {
@@ -62,16 +62,14 @@
   }
   &__detail {
     margin-left: 30px;
+    font-size: 15px;
     &--name {
-      font-size: 14px;
       padding: 0 0 8px;
       line-height: 1.5;
-      text-align: left;
     }
   }
   &__price-ja {
     padding-top: 20px;
-    font-size: 15px;
   }
 }
 
@@ -79,7 +77,6 @@
 .trades-new-buy-price-table {
   margin: 20px 0;
   display: table;
-  border-collapse: collapse;
   width: 100%;
   span {
     font-size: 20px;
@@ -110,7 +107,6 @@
     font-size: 14px;
   }
   &__card-number {
-    padding: 0;
     &--number{
       text-align: left;
       color: #3CCACE;

--- a/app/assets/stylesheets/modules/trades_new.scss
+++ b/app/assets/stylesheets/modules/trades_new.scss
@@ -70,3 +70,20 @@
     font-size: 15px;
   }
 }
+
+/*---支払金額---*/
+.trades-new-buy-price-table {
+  margin: 20px 0;
+  display: table;
+  border-collapse: collapse;
+  font-size: 20px;
+  width: 100%;
+  &__row {
+    display: table-row;
+  }
+  &__cell {
+    display: table-cell;
+    text-align: center;
+    padding: 0;
+  }
+}

--- a/app/assets/stylesheets/modules/trades_new.scss
+++ b/app/assets/stylesheets/modules/trades_new.scss
@@ -42,10 +42,13 @@
     padding: 32px;
   }
   &-alreay-submited {
-    color:#ea352d;
-    font-weight: bold;
-    font-size: 25px;
-    letter-spacing: 3.5px;
+    margin-bottom: 24px;
+    &__text {
+      color:#ea352d;
+      font-weight: bold;
+      font-size: 24px;
+      letter-spacing: 3.5px;
+    }
   }
 }
 
@@ -79,7 +82,7 @@
   border-collapse: collapse;
   width: 100%;
   span {
-    font-size: 22px;
+    font-size: 20px;
   }
   &__row {
     display: table-row;
@@ -92,12 +95,33 @@
 
 /*---支払方法---*/
 .trades-new-cash {
-  margin: 30px 0;
   padding: 20px 0;
   border-top: 1px solid #f5f5f5;
   &__icon {
     float: right;
     color: #3CCACE;
+  }
+}
+
+.creditcards-show-confirmation {
+  &__contents {
+    padding: 24px 0 0;
+    line-height: normal;
+    font-size: 14px;
+  }
+  &__card-number {
+    padding: 0;
+    &--number{
+      text-align: left;
+      color: #3CCACE;
+    }
+  }
+  &__expire {
+    margin-top: 0;
+    &--date {
+      text-align: left;
+      color: #3CCACE;
+    }
   }
 }
 
@@ -108,14 +132,12 @@
     color: #3CCACE;
   }
   &__info {
-    padding: 30px 0;
+    padding-top: 24px;
     line-height: normal;
   }
 }
 
-/*---戻るボタン---*/
 .trades-create-buy-content-inner {
-  margin: 30px 0;
   &__rootbtn {
     margin:0 auto;
     text-align: center;

--- a/app/assets/stylesheets/modules/trades_new.scss
+++ b/app/assets/stylesheets/modules/trades_new.scss
@@ -12,3 +12,27 @@
     }
   }
 }
+
+.trades-new-buy {
+/*---購入内容の確認---*/
+  &__head {
+    text-align: center;
+    font-weight: bold;
+    font-size: 24px;
+    height: 100px;
+    padding: 32px;
+  }
+
+  &-content {
+    padding: 32px 16px;
+    border-top: 1px solid #f5f5f5;
+      &-inner{
+      max-width: 343px;
+      margin: 0 auto;
+        h3 {
+          float: left;
+          font-size: 16px;
+        }
+      }
+  }
+}

--- a/app/assets/stylesheets/modules/trades_new.scss
+++ b/app/assets/stylesheets/modules/trades_new.scss
@@ -100,3 +100,14 @@
     color: #3CCACE;
   }
 }
+
+/*---配送先---*/
+.trades-new-cash-address {
+  &__edit {
+    float: right;
+    color: #3CCACE;
+  }
+  &__info {
+    padding: 25px 0;
+  }
+}

--- a/app/views/trades/new.html.haml
+++ b/app/views/trades/new.html.haml
@@ -1,5 +1,5 @@
 .trades-new
-  %header.trades-header
+  %header.trades-new-header
     .trades-header__icon
       = link_to root_path do
         = image_tag 'logo.png'
@@ -30,22 +30,22 @@
             = form_with(model: [@item, @trade],  local: true) do |f|
               %ul.trades-new-buy-price-table
                 %li.trades-new-buy-price-table__row
-                  .trades-new-buy-price-table__cell--label 支払い金額
+                  %span.trades-new-buy-price-table__cell--label 支払い金額
                   .trades-new-buy-price-table__cell
                     %span
                       = thousands_separator(@item.price)
-              .trades-new-buy-content
+              .trades-new-cash
                 .trades-new-buy-content-inner
                   %h3 支払い方法
                   - if @default_card_information.nil?
                     = link_to new_user_creditcard_path(current_user.id), class: "trades-new-buy-user-info-fix" do
-                      %p.trades-new-buy-user-info-text__cardinfo
-                        .trades-new-icon-plus-circle
+                      %p.trades-new-cash-text__cardinfo
+                        .trades-new-cash__icon
                           = icon('fas', 'plus-circle')
                           %span.trades-new-buy-register-text--new
-                            登録してください
+                            登録する
                   - else
-                    %p.trades-new-buy-user-info-text__cardinfo
+                    %p.trades-new-cash-text__cardinfo
                       .creditcards-show-confirmation__contents
                         .creditcards-show-confirmation__card-number
                           .creditcards-show-confirmation__card-number--text カード番号
@@ -57,27 +57,27 @@
                             - exp_month = @default_card_information.exp_month.to_s
                             - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
                             = exp_month + " 月 / " + exp_year + " 年"
-              .trades-new-buy-content
+              .trades-new-cash
                 .trades-new-buy-content-inner
                   %h3 配送先
                   - if @address.nil?
                     = link_to new_user_address_path(current_user.id), class: "trades-new-buy-user-info-fix" do
-                      %p.trades-new-buy-user-info-text
-                        .trades-new-icon-plus-circle
+                      %p.trades-new-cash-address
+                        .trades-new-cash__icon
                           = icon('fas', 'plus-circle')
                           %span.trades-new-buy-register-text 登録してください
                   - else
                     = link_to edit_user_address_path(current_user.id, @address.id), class: "trades-new-buy-user-info-fix" do
-                      %span.trades-new-buy-register-text--edit
+                      %span.trades-new-cash-address__edit
                         変更する
-                    %p.trades-new-buy-user-info-text__addressinfo
-                      = @address.postal_number 
+                    %p.trades-new-cash-address__info
+                      = "〒" + @address.postal_number
                       %br/
-                      = @address.city 
+                      = @address.city
                       %br/
-                      = @address.number 
+                      = @address.number
                       %br/
-                      = @address.building 
+                      = @address.building
               .trades-new-buy-content
                 .trades-new-buy-content-inner
                   = f.hidden_field :user_id
@@ -88,3 +88,4 @@
                   .trades-create-buy-content-inner
                     = submit_tag "購入する", class: "trades-create-buy-content-inner__submit"
   %footer.trades-new-footer
+  = render 'layouts/footer'

--- a/app/views/trades/new.html.haml
+++ b/app/views/trades/new.html.haml
@@ -4,8 +4,8 @@
       = link_to root_path do
         = image_tag 'logo.png'
   %main.trades-new-buy-main
-    .trades-new-buy-item-container
-      %h2.trades-new-buy-head 購入内容の確認
+    .trades-new-container
+      %h2.trades-new-buy__head 購入内容の確認
       .trades-new-buy-content
         .trades-new-buy-content-inner
           .trades-new-buy-item-box

--- a/app/views/trades/new.html.haml
+++ b/app/views/trades/new.html.haml
@@ -12,7 +12,7 @@
             %h3.trades-new-buy-item__image
               = image_tag @item.item_images.first.image.url, class:'trades-image'
               .trades-new-buy-item__detail
-                .trades-item__name 
+                .trades-item__name
                   = @item.title
                 .trades-new-buy-item__price-ja
                   %span
@@ -21,8 +21,9 @@
       .trades-new-buy-content
         .trades-new-buy-content-inner
           - if trade_submited?(@trade)
-            %span.trades-new-buy-alreay-submited
-              この商品は売約済みです。
+            .trades-new-buy-alreay-submited
+              %span.trades-new-buy-alreay-submited__text
+                この商品は売約済みです。
             .trades-create-buy-content-inner
               = link_to root_path do
                 = button_tag "戻る", class: "trades-create-buy-content-inner__rootbtn"
@@ -30,7 +31,7 @@
             = form_with(model: [@item, @trade],  local: true) do |f|
               %ul.trades-new-buy-price-table
                 %li.trades-new-buy-price-table__row
-                  %span.trades-new-buy-price-table__cell--label 支払い金額
+                  %h3.trades-new-buy-price-table__cell--label 支払い金額
                   .trades-new-buy-price-table__cell
                     %span
                       = thousands_separator(@item.price)
@@ -83,9 +84,9 @@
                   = f.hidden_field :user_id
                   = f.hidden_field :item_id
                   = f.hidden_field :address_id
-                .trades-new-buy-content
+                .trades-new-buy-content-inner
                 - if card_present_and_address_present?(@default_card_information, @address)
                   .trades-create-buy-content-inner
-                    = submit_tag "購入する", class: "trades-create-buy-content-inner__submit"
+                    = submit_tag "購入する", class: "trades-create-buy-content-inner__rootbtn"
   %footer.trades-new-footer
   = render 'layouts/footer'

--- a/app/views/trades/new.html.haml
+++ b/app/views/trades/new.html.haml
@@ -12,7 +12,7 @@
             %h3.trades-new-buy-item__image
               = image_tag @item.item_images.first.image.url, class:'trades-image'
               .trades-new-buy-item__detail
-                .trades-item__name
+                .trades-new-buy-item__detail--name
                   = @item.title
                 .trades-new-buy-item__price-ja
                   %span
@@ -66,7 +66,7 @@
                       %p.trades-new-cash-address
                         .trades-new-cash__icon
                           = icon('fas', 'plus-circle')
-                          %span.trades-new-buy-register-text 登録してください
+                          %span.trades-new-buy-register-text 登録する
                   - else
                     = link_to edit_user_address_path(current_user.id, @address.id), class: "trades-new-buy-user-info-fix" do
                       %span.trades-new-cash-address__edit


### PR DESCRIPTION
#what
購入確認画面のビューを実装した。
・購入者が支払情報を登録していない場合は、登録が必要。
・購入者が配送情報を登録していない場合は、登録が必要。
・購入者が支払情報と配送情報が登録している場合のみ、購入ボタンが表示される。
・商品が他の人に購入されている場合は「この商品は売約済みです。」と戻るボタンが表示される。

購入完了、購入失敗は別のプルリクで出します。

#why
購入予定の商品について、購入前に今一度確認するため。
購入者に必要な情報を入力させるため。

https://gyazo.com/630668a3f77e1c79feae223c1616e6f1
https://gyazo.com/585919db7d0a36573521e7674770e0a7
https://gyazo.com/67615176a1673a86062d1a58dc8cf4fb