### PR TITLE
購入失敗画面のマークアップ 

### DIFF
--- a/app/assets/stylesheets/modules/_trades-fail.scss
+++ b/app/assets/stylesheets/modules/_trades-fail.scss
@@ -1,0 +1,59 @@
+.trades-fail-buy-content {
+  padding: 32px 16px;
+  border-bottom: 1px solid #f5f5f5;
+}
+
+.trades-fail-buy-content-inner {
+  max-width: 343px;
+  margin: 0 auto;
+  h2{
+    color:#ea352d;
+    font-weight: bold;
+    font-size: 24px;
+    letter-spacing: 4px;
+    text-align: center;
+  }
+  &__rootbtn {
+    margin:0 auto;
+    margin-bottom: 30px;
+    text-align: center;
+    font-size: 18px;
+    line-height: 48px;
+    background: #3CCACE;
+    border: 1px solid #3CCACE;
+    width: 100%;
+    border-radius: 100px;
+    color: #fff;
+    text-decoration: none;
+  }
+}
+
+.trades-fail-buy-head {
+  text-align: center;
+  font-weight: bold;
+  font-size: 24px;
+  height: 100px;
+  padding: 32px;
+  border-bottom: 1px solid #f5f5f5;
+}
+
+.trades-fail-buy-item {
+  &-container {
+    width:700px;
+    margin:0 auto;
+    background-color: rgb(255, 255, 255);
+  }
+  &-box {
+    display: flex;
+  }
+  &__image {
+    display: flex;
+  }
+  &__detail {
+    margin-left: 30px;
+    font-size: 15px;
+  }
+  &__price-ja {
+    padding-top: 20px;
+  }
+}

--- a/app/assets/stylesheets/modules/_trades-fail.scss
+++ b/app/assets/stylesheets/modules/_trades-fail.scss
@@ -1,3 +1,18 @@
+.trades-fail {
+  background-color: rgb(245, 245, 245);
+  align-items: center;
+  &-header {
+    height: 120px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    &__icon {
+      height: 50px;
+      width: 200px;
+    }
+  }
+}
+
 .trades-fail-buy-content {
   padding: 32px 16px;
   border-bottom: 1px solid #f5f5f5;
@@ -52,6 +67,10 @@
   &__detail {
     margin-left: 30px;
     font-size: 15px;
+    &--name {
+      padding: 0 0 8px;
+      line-height: 1.5;
+    }
   }
   &__price-ja {
     padding-top: 20px;

--- a/app/views/trades/fail.html.haml
+++ b/app/views/trades/fail.html.haml
@@ -1,6 +1,6 @@
-.trades-new
-  %header.trades-header
-    .trades-header__icon
+.trades-fail
+  %header.trades-fail-header
+    .trades-fail-header__icon
       = link_to root_path do
         = image_tag 'logo.png'
   %main.trades-fail-main
@@ -13,7 +13,7 @@
             %h3.trades-fail-buy-item__image
               = image_tag @item.item_images.first.image.url, class:'trades-image'
               .trades-fail-buy-item__detail
-                .trades-item__name 
+                .trades-fail-buy-item__detail--name
                   = @item.title
                 .trades-fail-buy-item__price-ja
                   %span
@@ -25,5 +25,6 @@
             .trades-fail-buy-content-inner
               %h2 購入に失敗しました。
           = link_to new_item_trade_path(@item.id) do
-            = button_tag "購入画面に戻る"
-  %footer.trades75x75footer
+            = button_tag "購入画面に戻る", class: "trades-fail-buy-content-inner__rootbtn"
+  %footer.trades-fail-footer
+    = render 'layouts/footer'


### PR DESCRIPTION
#what
購入に失敗した時のビューを実装した。

#why
支払方法が有効でない場合など、決済が正常に完了しないことも想定されるため。

[![Screenshot from Gyazo](https://gyazo.com/022a40de7463993627a8e9c2dc2b14c2/raw)](https://gyazo.com/022a40de7463993627a8e9c2dc2b14c2)