### PR TITLE
issue #119、#120、#121、#125の修正パッチ

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -65,14 +65,14 @@
         display: flex;
       }
       &__Left {
-        width:100px;
+        width:auto;
         font-size: 14px;
         height:44px;
         line-height: 44px;
         padding:0 10px;
       }
       &__Right {
-        width:100px;
+        width:auto;
         font-size: 14px;
         height:44px;
         line-height: 44px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,7 @@ class ItemsController < ApplicationController
       @item["profit_price"] = @item.price - (@item.price * @item.feerate)
     else
       redirect_to new_item_path, notice:"販売価格を入力してください"
+      return
     end
     if params[:item_images] 
       if @item.save
@@ -64,6 +65,7 @@ class ItemsController < ApplicationController
       render :destroy
     else
       redirect_to item_path(@item.id), notice:"商品を削除できませんでした"
+      return
     end
   end
 
@@ -77,7 +79,11 @@ class ItemsController < ApplicationController
     end
 
     def set_user_address
-      @address = Address.find_by(user_id: current_user.id,status_num: 0)
+      if @address = Address.find_by(user_id: current_user.id,status_num: 0)
+      else
+        redirect_to user_addresses_path(current_user.id), notice:"アドレスの登録がないと商品の登録ができません。"
+        return
+      end
     end
 
     def set_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,6 +27,9 @@ class ItemsController < ApplicationController
         params[:item_images]['image'].each do |img|
           @image = @item.item_images.create(image: img, item_id: @item.id)
         end
+      else
+        redirect_to new_item_path, notice:"必要な情報が不足していたため商品が登録できませんでした。"
+        return
       end
       @item = Item.find(@item.id)
       if @item.item_images.empty?

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -108,7 +108,7 @@
               = f.label :"販売価格"
               %span.form-require 必須
             %br/
-            = f.text_field :price, data: { autonumeric: { aSign: '¥', mDec: 0 } } , placeholder: "金額を入力して下さい"
+            = f.text_field :price, data: { autonumeric: { aSign: '¥', mDec: 0 ,vMax:9999999} } , placeholder: "金額を入力して下さい"
           .items-final__commission
             .items-final__commission--factor
               %div

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -93,7 +93,7 @@
               = f.label :"販売価格"
               %span.form-require 必須
             %br/
-            = f.text_field :price, data: {autonumeric: { aSign: '¥', mDec: 0 } } , placeholder: "金額を入力して下さい"
+            = f.text_field :price, data: {autonumeric: { aSign: '¥', mDec: 0 ,vMax:9999999} } , placeholder: "金額を入力して下さい"
           .items-final__commission
             .items-final__commission--factor
               %div


### PR DESCRIPTION
#why
各Issueで報告された不具合の修正のため。

#what
issue#119
・販売価格が規定値(¥10,000,000)以上の場合エラーとなる。
　→最大値9,999,999の制限を追加
・必要な情報が不足していた場合にエラーとなる。
 ※修正後GIF動画
[![Screenshot from Gyazo](https://gyazo.com/d11a9d7a8729b45dac8193cc7f0e7f52/raw)](https://gyazo.com/d11a9d7a8729b45dac8193cc7f0e7f52)

issue#120 
・新規会員登録ボタンのlength不足。
 ※修正後スクリーンショット
[![Screenshot from Gyazo](https://gyazo.com/7244cc52c7ff91d375e863ac28698b83/raw)](https://gyazo.com/7244cc52c7ff91d375e863ac28698b83)

issue#121
・ユーザのアドレス登録がないまま出品しようとした際にエラーとなる。
 ※修正後GIF動画
　[![Screenshot from Gyazo](https://gyazo.com/c6c749e0694cec2c291581ff29ac46de/raw)](https://gyazo.com/c6c749e0694cec2c291581ff29ac46de)

issue#125
・商品情報を一切入力しないまま出品しようとするとエラーとなる。
 ※修正後GIF動画
[![Screenshot from Gyazo](https://gyazo.com/096b5c030c9b6598c0603efed9692bd1/raw)](https://gyazo.com/096b5c030c9b6598c0603efed9692bd1)