### PR TITLE
issue #127の修正パッチ

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -8,9 +8,6 @@ $(document).on('turbolinks:load', function() {
             <img src="${loadedImageUri}">
           </div>
           <div class="image-option">
-            <div  class="image-option__list">
-              <div class="image-option__list--edit">編集</div>
-            </div>
             <div class="image-option__list">
               <div class="image-option__list--delete">削除</div>
             </div>
@@ -126,9 +123,6 @@ $(document).on('turbolinks:load', function() {
             <img src="${loadedImageUri}">
           </div>
           <div class="image-option">
-            <div  class="image-option__list">
-              <div class="image-option__list--edit">編集</div>
-            </div>
             <div class="image-option__list">
               <div class="image-option__list--delete">削除</div>
             </div>

--- a/app/assets/stylesheets/_item-image-container.scss
+++ b/app/assets/stylesheets/_item-image-container.scss
@@ -89,7 +89,7 @@
   height: 40px;
   line-height: 40px;
   &__list{
-    a{
+    &--delete{
       display: block;
       color: black;
       cursor: pointer;


### PR DESCRIPTION
#why
編集ボタンが存在するものの現在は機能を実装していないため、ユーザビリティを考慮して一旦消去する。

#what
出品画面と編集画面で編集ボタンが消去されているか。
※出品画面
[![Screenshot from Gyazo](https://gyazo.com/635640b3bb88729b3656ddcb1e1e8a69/raw)](https://gyazo.com/635640b3bb88729b3656ddcb1e1e8a69)

※編集画面
[![Screenshot from Gyazo](https://gyazo.com/06197cedf33ae8d3fda3d6e288596082/raw)](https://gyazo.com/06197cedf33ae8d3fda3d6e288596082)