### PR TITLE
商品出品、商品編集で販売手数料、販売利益の表示に対応(ISSUE#124)

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -49,7 +49,7 @@ $(document).on('turbolinks:load', function() {
       labelWidth = (620 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
       $('.item-image-container__unit--guide').css('width', labelWidth);
     }
-  // プレビューの追加
+    // プレビューの追加
     $(document).on('change', '.hidden-field', function() {
       //hidden-fieldのidの数値のみ取得
       var id = $(this).attr('id').replace(/[^0-9]/g, '');
@@ -85,7 +85,7 @@ $(document).on('turbolinks:load', function() {
       };
     });
 
-  // 画像の削除
+    // 画像の削除
     $(document).on('click', '.image-option__list--delete', function() {
 
       var id = $(this).parent().parent().parent().attr('data-image-id')
@@ -168,30 +168,30 @@ $(document).on('turbolinks:load', function() {
       $('#click-delete').css('display','none');
     });
 
-  $('.item-image-container__unit--guide').on('dragover',function(e){
-    e.preventDefault();
-  });
-  $('.item-image-container__unit--guide').on('drop',function(e){
-    e.preventDefault();
-    var files = e.originalEvent.dataTransfer.files;
-    imageUpdate(files)
-    $('#d-d-delete').css('display','none')
-    $('#click-delete').css('display','none');
-  });
+    $('.item-image-container__unit--guide').on('dragover',function(e){
+      e.preventDefault();
+    });
+    $('.item-image-container__unit--guide').on('drop',function(e){
+      e.preventDefault();
+      var files = e.originalEvent.dataTransfer.files;
+      imageUpdate(files)
+      $('#d-d-delete').css('display','none')
+      $('#click-delete').css('display','none');
+    });
 
-  $(document).on('click','.image-option__list--delete',function(){
-    var index = $(".image-option__list--delete").index(this);
-    var id = $(this).parent().parent().parent().attr('data-image-id')
-    files_array.splice(index - 1, 1);
-    $(this).parent().parent().parent().remove();
-    dataBox.items.remove(dataBox.items[id])
-    file_field.files = dataBox.files
-    if(dataBox.items.length == 0){
-      $('#d-d-delete').css('display','block')
-      $('#click-delete').css('display','block');
-    }
-  });
-}
+    $(document).on('click','.image-option__list--delete',function(){
+      var index = $(".image-option__list--delete").index(this);
+      var id = $(this).parent().parent().parent().attr('data-image-id')
+      files_array.splice(index - 1, 1);
+      $(this).parent().parent().parent().remove();
+      dataBox.items.remove(dataBox.items[id])
+      file_field.files = dataBox.files
+      if(dataBox.items.length == 0){
+        $('#d-d-delete').css('display','block')
+        $('#click-delete').css('display','block');
+      }
+    });
+  }
 
   //ここからカテゴリの段階的表示機能
   function buildHTML(result){

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -342,7 +342,7 @@ $(document).on('turbolinks:load', function() {
     let commission_price = "";
     let prifit_price = "";
     if (Number.isFinite(price) && Number.isFinite(rate)) {
-      commission_price = price * rate
+      commission_price = Math.floor(price * rate)
       prifit_price = price - (commission_price);
     }
     //販売手数料の更新(label)

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -337,7 +337,10 @@ $(document).on('turbolinks:load', function() {
 
   //ここから価格設定後の金額表示処理
   const NumberWithDelimiter = (number) => {
-    return "¥" + String(number).replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+    if (number != "") {
+      number = "¥" + String(number).replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+    }
+    return number;
   }
   $("#item_price").change(function () {
     let price = parseInt($("#item_price").val().replace(/[^0-9]/g, ''));

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -345,13 +345,17 @@ $(document).on('turbolinks:load', function() {
   $("#item_price").change(function () {
     let price = parseInt($("#item_price").val().replace(/[^0-9]/g, ''));
     let rate = parseFloat($("#item_feerate").val());
+    let commission_price = "";
     let prifit_price = "";
     if (Number.isFinite(price) && Number.isFinite(rate)) {
-      prifit_price = price - (price * rate);
+      commission_price = price * rate
+      prifit_price = price - (commission_price);
     }
-    //販売履歴の更新(label)
+    //販売手数料の更新(label)
+    $("#item_commission_price_label").val(NumberWithDelimiter(commission_price));
+    //販売利益の更新(label)
     $("#item_profit_price_label").val(NumberWithDelimiter(prifit_price));
-    //販売履歴の更新(hidden)
+    //販売利益の更新(hidden)
     $("#profit_price_hdn").val(prifit_price);
   });
 });

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -334,4 +334,21 @@ $(document).on('turbolinks:load', function() {
       });
     }
   });
+
+  //ここから価格設定後の金額表示処理
+  const NumberWithDelimiter = (number) => {
+    return "¥" + String(number).replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+  }
+  $("#item_price").change(function () {
+    let price = parseInt($("#item_price").val().replace(/[^0-9]/g, ''));
+    let rate = parseFloat($("#item_feerate").val());
+    let prifit_price = "";
+    if (Number.isFinite(price) && Number.isFinite(rate)) {
+      prifit_price = price - (price * rate);
+    }
+    //販売履歴の更新(label)
+    $("#item_profit_price_label").val(NumberWithDelimiter(prifit_price));
+    //販売履歴の更新(hidden)
+    $("#profit_price_hdn").val(prifit_price);
+  });
 });

--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -155,6 +155,7 @@
     align-items: center;
     box-sizing: content-box;
     display: flex;
+    justify-content: space-between;
     height: 46px;
 
     &--factor{
@@ -165,7 +166,6 @@
 
   &__profit{
     @extend .items-final__commission;
-    justify-content: space-between;
     &--factor{
       @extend .items-final__commission--factor;
     }
@@ -246,9 +246,16 @@
 }
 
 %__price-form{
+  margin-top: initial;
   width: 50%;
   height: 50px;
   border-radius: 4px;
+}
+
+%__commission-and-profit-form{
+  border: 0px;
+  text-align: left;
+  line-height: 3;
 }
 
 #parent{
@@ -291,13 +298,18 @@
   @extend %__price-form;
 }
 
+#item_commission_price_label{
+  @extend %__select-form;
+  @extend %__price-form;
+  @extend %__commission-and-profit-form
+}
+
 #item_profit_price_label{
   @extend %__select-form;
   @extend %__price-form;
-  border: 0px;
-  text-align: left;
-  line-height: 3;
+  @extend %__commission-and-profit-form
 }
+
 // file_fieldのcss
 .hidden-content {
   .hidden-field {

--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -301,13 +301,13 @@
 #item_commission_price_label{
   @extend %__select-form;
   @extend %__price-form;
-  @extend %__commission-and-profit-form
+  @extend %__commission-and-profit-form;
 }
 
 #item_profit_price_label{
   @extend %__select-form;
   @extend %__price-form;
-  @extend %__commission-and-profit-form
+  @extend %__commission-and-profit-form;
 }
 
 // file_fieldのcss

--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -245,6 +245,12 @@
   padding: 0 56px 0 16px;
 }
 
+%__price-form{
+  width: 50%;
+  height: 50px;
+  border-radius: 4px;
+}
+
 #parent{
  @extend %__select-form;
 }
@@ -282,17 +288,15 @@
 
 #item_price{
   @extend %__select-form;
-  width: 50%;
-  height: 50px;
-  border-radius: 4px;
+  @extend %__price-form;
 }
 
-#item_profit_price{
+#item_profit_price_label{
   @extend %__select-form;
-  width: 50%;
-  height: 50px;
-  border-radius: 4px;
+  @extend %__price-form;
   border: 0px;
+  text-align: left;
+  line-height: 3;
 }
 // file_fieldのcss
 .hidden-content {

--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -165,6 +165,7 @@
 
   &__profit{
     @extend .items-final__commission;
+    justify-content: space-between;
     &--factor{
       @extend .items-final__commission--factor;
     }
@@ -286,6 +287,13 @@
   border-radius: 4px;
 }
 
+#item_profit_price{
+  @extend %__select-form;
+  width: 50%;
+  height: 50px;
+  border-radius: 4px;
+  border: 0px;
+}
 // file_fieldのcss
 .hidden-content {
   .hidden-field {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,7 +25,6 @@ class ItemsController < ApplicationController
       return
     end
     if params[:item_images] 
-      binding.pry
       if @item.save
         params[:item_images]['image'].each do |img|
           @image = @item.item_images.create(image: img, item_id: @item.id)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,11 +16,13 @@ class ItemsController < ApplicationController
     @item = Item.new(item_params)
     @item["user_id"] = current_user.id
     @item["address_id"] = @address.id
-    @item["feerate"] = 0.1
-    if @item["price"] != nil
-      @item["profit_price"] = @item.price - (@item.price * @item.feerate)
-    else
+    if @item.price.nil?
       redirect_to new_item_path, notice:"販売価格を入力してください"
+      return
+    end
+    if @item.profit_price.nil?
+      redirect_to new_item_path, notice:"販売利益の取得に失敗しました。販売価格をもう一度入力してください"
+      return
     end
     if params[:item_images] 
       binding.pry
@@ -74,7 +76,7 @@ class ItemsController < ApplicationController
 
   private
     def item_params
-      params.require(:item).permit(:brand_id,:category_id,:shippingway_id,:product_size_id,:condition_num,:daystoship_num,:title,:description,:price, [item_images_attributes: [:id, :image]])
+      params.require(:item).permit(:brand_id,:category_id,:shippingway_id,:product_size_id,:condition_num,:daystoship_num,:title,:description,:price,:feerate,:profit_price, [item_images_attributes: [:id, :image]])
     end
 
     def item_update_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -86,10 +86,6 @@ class ItemsController < ApplicationController
       params.require(:item).permit(:brand_id,:category_id,:shippingway_id,:product_size_id,:condition_num,:daystoship_num,:title,:description,:price,:feerate,:profit_price, [item_images_attributes: [:image, :_destroy, :id]])
     end
 
-    def calc_profit_price(item)
-      item["profit_price"] = item.price - (item.price * item.feerate)
-    end
-
     def set_user_address
       if @address = Address.find_by(user_id: current_user.id,status_num: 0)
       else
@@ -100,7 +96,6 @@ class ItemsController < ApplicationController
 
     def set_item
       @item = Item.find(params[:id])
-      @item.price = @item.price.to_i
     end
     def set_categories
       @categories = []

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,7 @@ class ItemsController < ApplicationController
   
   def new
     @item = Item.new(feerate: 0.1)
+    @item.feerate = 0.1
     @item_image = @item.item_images.build
   end
 
@@ -15,11 +16,17 @@ class ItemsController < ApplicationController
     @item = Item.new(item_params)
     @item["user_id"] = current_user.id
     @item["address_id"] = @address.id
-    @item["feerate"] = 0.1
-    if @item["price"] != nil
-      @item["profit_price"] = @item.price - (@item.price * @item.feerate)
-    else
+    # @item["feerate"] = 0.1
+    # if @item["price"] != nil
+    #   @item["profit_price"] = @item.price - (@item.price * @item.feerate)
+    # else
+    #   redirect_to new_item_path, notice:"販売価格を入力してください"
+    # end
+    if @item["price"] = nil
       redirect_to new_item_path, notice:"販売価格を入力してください"
+    end
+    if @item["profit_price"] = nil
+      redirect_to new_item_path, notice:"販売価格を入力して販売履歴を確定してください"
     end
     if params[:item_images] 
       if @item.save
@@ -69,11 +76,13 @@ class ItemsController < ApplicationController
 
   private
     def item_params
-      params.require(:item).permit(:brand_id,:category_id,:shippingway_id,:product_size_id,:condition_num,:daystoship_num,:title,:description,:price, [item_images_attributes: [:id, :image]])
+      binding.pry
+      params.require(:item).permit(:brand_id,:category_id,:shippingway_id,:product_size_id,:condition_num,:daystoship_num,:title,:description,:price,:feerate,:profit_price, [item_images_attributes: [:id, :image]])
     end
 
     def item_update_params
-      params.require(:item).permit(:brand_id,:category_id,:shippingway_id,:product_size_id,:condition_num,:daystoship_num,:title,:description,:price, [item_images_attributes: [:image, :_destroy, :id]])
+      binding.pry
+      params.require(:item).permit(:brand_id,:category_id,:shippingway_id,:product_size_id,:condition_num,:daystoship_num,:title,:description,:price,:feerate,:profit_price, [item_images_attributes: [:image, :_destroy, :id]])
     end
 
     def set_user_address
@@ -82,6 +91,7 @@ class ItemsController < ApplicationController
 
     def set_item
       @item = Item.find(params[:id])
+      @item.price = @item.price.to_i
     end
     def set_categories
       @categories = []

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -8,6 +8,10 @@ module ItemsHelper
     EOS
   end
 
+  def disp_ratepercent(rate)
+    return "#{(rate * 100).to_i}%"
+  end
+
   def thousands_separator(price)
     # 現状はJPY固定。
     number_to_currency(price, format: "%u%n", unit: "￥", strip_insignificant_zeros: true)

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -8,12 +8,12 @@ module ItemsHelper
     EOS
   end
 
-  def disp_ratepercent(rate)
-    return "#{(rate * 100).to_i}%"
-  end
-
   def thousands_separator(price)
     # 現状はJPY固定。
     number_to_currency(price, format: "%u%n", unit: "￥", strip_insignificant_zeros: true)
+  end
+
+  def disp_ratepercent(rate)
+    return "#{(rate * 100).to_i}%"
   end
 end

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -108,17 +108,17 @@
               = f.label :price, "販売価格"
               %span.form-require 必須
             %br/
-            = f.text_field :price, data: { autonumeric: { aSign: '¥', mDec: 0 ,vMax:9999999} } , placeholder: "金額を入力して下さい", value: thousands_separator(@item.price)
+            = f.text_field :price, data: { autonumeric: { aSign: '¥', mDec: 0 ,vMax:9999999} }, placeholder: "金額を入力して下さい", value: @item.price
           .items-final__commission
             .items-final__commission--factor
               = f.label :feerate, "販売手数料(#{disp_ratepercent(@item.feerate)})"
               = f.hidden_field :feerate
-            = f.text_field :commission_price_label, value: thousands_separator(@item.price * @item.feerate), disabled: true
+            = f.text_field :commission_price_label, data: { autonumeric: { aSign: '¥', mDec: 0 ,vMax:9999999} }, value: (@item.price * @item.feerate), disabled: true
           .items-final__profit
             .items-final__profit--factor
               %div
                 販売利益(販売価格 - 手数料)
-            = f.text_field :profit_price_label, value: thousands_separator(@item.profit_price), disabled: true
+            = f.text_field :profit_price_label, data: { autonumeric: { aSign: '¥', mDec: 0 ,vMax:9999999} }, value: @item.profit_price, disabled: true
             = f.hidden_field :profit_price, id: "profit_price_hdn"
           %hr.items-hr
           %br/

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -113,10 +113,11 @@
             .items-final__commission--factor
               = f.label :feerate, "販売手数料(#{disp_ratepercent(@item.feerate)})"
               = f.hidden_field :feerate
+            = f.text_field :commission_price_label, value: thousands_separator(@item.price * @item.feerate), disabled: true
           .items-final__profit
             .items-final__profit--factor
               %div
-                販売利益
+                販売利益(販売価格 - 手数料)
             = f.text_field :profit_price_label, value: thousands_separator(@item.profit_price), disabled: true
             = f.hidden_field :profit_price, id: "profit_price_hdn"
           %hr.items-hr

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -105,19 +105,22 @@
             価格 (¥200~9,999,999)
           .items-final__head
             .items-final__head--inner
-              = f.label :"販売価格"
+              = f.label :price, "販売価格"
               %span.form-require 必須
             %br/
             = f.text_field :price, data: { autonumeric: { aSign: '¥', mDec: 0 } } , placeholder: "金額を入力して下さい"
+            = f.hidden_field :price
           .items-final__commission
             .items-final__commission--factor
-              %div
-                販売手数料(10%)
-          %hr.items-hr
+              = f.label :feerate, "販売手数料(#{disp_ratepercent(@item.feerate)})"
+              = f.hidden_field :feerate
           .items-final__profit
             .items-final__profit--factor
               %div
                 販売利益
+            = f.text_field :profit_price, value: thousands_separator(@item.profit_price), disabled: true
+          %hr.items-hr
+          %br/
           .items-final__exibition
             .exibition-n-back
               = f.submit "出品する",class:"exibition-n-back__submit" , data: { confirm: '入力した情報で出品します。よろしいですか？' }

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -108,8 +108,7 @@
               = f.label :price, "販売価格"
               %span.form-require 必須
             %br/
-            = f.text_field :price, data: { autonumeric: { aSign: '¥', mDec: 0 } } , placeholder: "金額を入力して下さい"
-            = f.hidden_field :price
+            = f.text_field :price, data: { autonumeric: { aSign: '¥', mDec: 0 } } , placeholder: "金額を入力して下さい", value: thousands_separator(@item.price)
           .items-final__commission
             .items-final__commission--factor
               = f.label :feerate, "販売手数料(#{disp_ratepercent(@item.feerate)})"
@@ -118,7 +117,8 @@
             .items-final__profit--factor
               %div
                 販売利益
-            = f.text_field :profit_price, value: thousands_separator(@item.profit_price), disabled: true
+            = f.text_field :profit_price_label, value: thousands_separator(@item.profit_price), disabled: true
+            = f.hidden_field :profit_price, id: "profit_price_hdn"
           %hr.items-hr
           %br/
           .items-final__exibition

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -98,13 +98,15 @@
             .items-final__commission--factor
               = f.label :feerate, "販売手数料(#{disp_ratepercent(@item.feerate)})"
               = f.hidden_field :feerate
-          %hr.items-hr
+            = f.text_field :commission_price_label, disabled: true
           .items-final__profit
             .items-final__profit--factor
               %div
-                販売利益
+                販売利益(販売価格 - 手数料)
             = f.text_field :profit_price_label, disabled: true
             = f.hidden_field :profit_price, id: "profit_price_hdn"
+          %hr.items-hr
+          %br/
           .items-final__exibition
             .exibition-n-back
               = f.submit "出品する",class:"exibition-n-back__submit" , data: { confirm: '入力した情報で出品します。よろしいですか？' }

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -103,6 +103,8 @@
             .items-final__profit--factor
               %div
                 販売利益
+            = f.text_field :profit_price_label, disabled: true
+            = f.hidden_field :profit_price, id: "profit_price_hdn"
           .items-final__exibition
             .exibition-n-back
               = f.submit "出品する",class:"exibition-n-back__submit" , data: { confirm: '入力した情報で出品します。よろしいですか？' }

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -93,17 +93,17 @@
               = f.label :"販売価格"
               %span.form-require 必須
             %br/
-            = f.text_field :price, data: {autonumeric: { aSign: '¥', mDec: 0 ,vMax:9999999} } , placeholder: "金額を入力して下さい"
+            = f.text_field :price, data: {autonumeric: { aSign: '¥', mDec: 0 ,vMax:9999999} }, placeholder: "金額を入力して下さい"
           .items-final__commission
             .items-final__commission--factor
               = f.label :feerate, "販売手数料(#{disp_ratepercent(@item.feerate)})"
               = f.hidden_field :feerate
-            = f.text_field :commission_price_label, disabled: true
+            = f.text_field :commission_price_label, data: {autonumeric: { aSign: '¥', mDec: 0 ,vMax:9999999} }, disabled: true
           .items-final__profit
             .items-final__profit--factor
               %div
                 販売利益(販売価格 - 手数料)
-            = f.text_field :profit_price_label, disabled: true
+            = f.text_field :profit_price_label, data: {autonumeric: { aSign: '¥', mDec: 0 ,vMax:9999999} }, disabled: true
             = f.hidden_field :profit_price, id: "profit_price_hdn"
           %hr.items-hr
           %br/

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -96,8 +96,8 @@
             = f.text_field :price, data: {autonumeric: { aSign: '¥', mDec: 0 } } , placeholder: "金額を入力して下さい"
           .items-final__commission
             .items-final__commission--factor
-              %div
-                販売手数料(10%)
+              = f.label :feerate, "販売手数料(#{disp_ratepercent(@item.feerate)})"
+              = f.hidden_field :feerate
           %hr.items-hr
           .items-final__profit
             .items-final__profit--factor

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -100,10 +100,12 @@
                     %h3.tops-index-content-picup-list-body__name 
                       = item.title
                     .tops-index-content-picup-list-body__details  
-                      %ul
-                        %li
+                      -if item.trade.present?
+                        %i.sold-out soldout
+                      -else
+                        %i
                           = thousands_separator(item.price)
-                      %p (税込)
+                        %i (税込)
 
   = render 'layouts/tertiarybanner'
   = render 'layouts/footer'


### PR DESCRIPTION
### why

出品者が商品の手数料と販売利益を把握出来るようにすることが必要なため。

### what

商品出品、商品編集に対応するために、下記に通りに修正した。

1. items.jsのインデントが正しくない箇所を修正。
1. 販売価格を入力後に、販売手数料と販売利益を計算するように対応。
1. 販売手数料、販売利益の表示用にCSSを編集。
1. @item.feerateは、インスタンス変数初期化時に設定するように対応。
1. @item.price, @item.profit_]priceがnilの時の処理を修正。
1. @item.price, @item.profit_]priceがnilの時の処理を修正。
1. トップ画面の「ピックアップブランド」での商品表示にも『soldout』に対応。

[![Screenshot from Gyazo](https://gyazo.com/4996fcda0977e449d617262a7fcb5d74/raw)](https://gyazo.com/4996fcda0977e449d617262a7fcb5d74)

[![Screenshot from Gyazo](https://gyazo.com/6ff6e928df94ab6546896c067afd3f70/raw)](https://gyazo.com/6ff6e928df94ab6546896c067afd3f70)

