### PR TITLE
issue #129の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -56,16 +56,28 @@ class ItemsController < ApplicationController
   end
 
   def update
-    item = Item.find(params[:id])
-    if params[:item]['item_images_attributes']['0']['_destroy'] == "1"
-      redirect_to edit_item_path(item.id), notice:"画像がない商品は登録できません。"
-    else
-      if item.update(item_update_params)
-        redirect_to item_path(item.id)
+    @item = Item.find(params[:id])
+    length = @item.item_images.length
+    i = 0
+    while i < length do
+      if  item_update_params[:item_images_attributes]["#{i}"]["_destroy"] == "0"
+        if @item.update(item_update_params)
+          redirect_to item_path(@item.id)
+          return
+        else
+          redirect_to item_path(item.id), notice:"出品情報の更新に失敗しました。"
+          return
+        end
       else
-        redirect_to item_path(item.id), notice:"出品情報の更新に失敗しました。"
+        i += 1
       end
     end
+    if item_update_params[:item_images_attributes]["#{i}"]
+      @item.update(item_update_params)
+      redirect_to item_path(@item.id)
+      return
+    end
+    redirect_to edit_item_path(@item.id), notice:"画像がない商品は登録できません。"
   end
 
   def destroy

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -18,7 +18,7 @@
             %ul
             .item-image-container__unit--guide
               //プレビューの数に合わせてforオプションを指定
-              = f.label :"item_images_attributes_#{@item.item_images.length}_image", class: "label-box", id: "label-box--#{@item.item_images.length}" do
+              = f.label :"item_images_attributes_#{@item.item_images.length}_image", class: "label-box" do
                 %div.image-upload-dropfile-entire
                   .have-image
                     %p#click-delete クリックしてファイルをアップロード


### PR DESCRIPTION
#why
１枚のみ画像がある商品で画像を追加後に既存の画像を削除して編集した際に商品登録できない不具合があり、修正の必要がある。

#what
１枚のみ画像がある商品で画像を追加後に既存の画像を削除して編集した際に画像が差し替えられること。

[![Screenshot from Gyazo](https://gyazo.com/d7432fd4f1f08aa860a41a28c1eac468/raw)](https://gyazo.com/d7432fd4f1f08aa860a41a28c1eac468)